### PR TITLE
fix(deps): pin zod to v3 to unbreak dependabot lockfile updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "typescript": "^5.8.3",
     "uuid": "^13.0.0",
     "vitest": "^4.0.14",
-    "zod": "^3.25 || ^4.0"
+    "zod": "^3.25"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": ">=1.11"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
         specifier: ^4.0.14
         version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@22.15.21)(@vitest/ui@4.0.14)(yaml@2.8.0)
       zod:
-        specifier: ^3.25 || ^4.0
+        specifier: ^3.25
         version: 3.25.30
 
 packages:


### PR DESCRIPTION
## Problem

Dependabot PRs #41 and #42 fail the "MCP SDK Version Compatibility Testing" workflow on all Node versions with:

```
keyValidator._parse is not a function
❌ Not compatible with @modelcontextprotocol/sdk@1.11.5
```

The bumps themselves (vitest, uuid) are innocent. When Dependabot regenerated `pnpm-lock.yaml`, the resolver re-answered every floating range with the newest allowed version — and the old `"zod": "^3.25 || ^4.0"` range let zod jump from 3.25.30 to 4.4.3. Old MCP SDK versions in the compatibility matrix are incompatible with zod 4, so 53 tests fail.

## Fix

Narrow the devDependency range to `"zod": "^3.25"` (>=3.25 <4). This formalizes what was already true in practice — everything has been running on zod 3 — so no future lockfile regeneration can flip it to v4 again. zod is a devDependency only (it satisfies the MCP SDK's peer requirement in tests), so nothing changes for consumers.

If/when zod 4 test coverage becomes a priority, the better long-term approach is to have the compatibility workflow install `zod@^3.25` alongside old SDK versions and let the main suite run zod 4.

## Verification

- `vitest run`: 471 passed, 1 skipped
- Replicated the failing CI job locally: installed `@modelcontextprotocol/sdk@1.11.5` with the pinned zod 3 — all 471 tests pass (previously 53 failures)

## After merging

Comment `@dependabot rebase` on #41 and #42 so they regenerate their lockfiles on top of this fix and go green.