### PR TITLE
The final mcpcat release — this SDK is now agentcat 🐱

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> **MCPcat is now AgentCat** 🐱 — same team, same product, new name. This package has been renamed to [`agentcat`](https://www.npmjs.com/package/agentcat) (`npm install agentcat`, starts at v1.0.0). `mcpcat` keeps working forever, but new features land only in `agentcat`. Upgrading takes a few minutes — see the [migration guide](./MIGRATION.md).
+
 <div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/static/logo-dark.svg">

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcpcat",
-  "version": "0.1.16",
-  "description": "Analytics tool for MCP (Model Context Protocol) servers - tracks tool usage patterns and provides insights",
+  "version": "0.1.17",
+  "description": "[DEPRECATED — mcpcat is now agentcat: npm install agentcat] Analytics tool for MCP (Model Context Protocol) servers - tracks tool usage patterns and provides insights",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -26,6 +26,7 @@
     "prepublishOnly": "pnpm run build && pnpm run test && pnpm run lint && pnpm run typecheck"
   },
   "keywords": [
+    "agentcat",
     "ai",
     "authentication",
     "mcp",

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,19 @@ import { validateTags } from "./modules/validation.js";
 import { eventQueue } from "./modules/eventQueue.js";
 import { initDiagnostics } from "./modules/diagnostics.js";
 
+// The mcpcat package is deprecated in favor of agentcat (same SDK, new name).
+// Surface that once per process in ~/mcpcat.log — never on stdout/stderr,
+// which would corrupt STDIO-based MCP servers.
+let renameNoticeLogged = false;
+
+function logRenameNoticeOnce(): void {
+  if (renameNoticeLogged) return;
+  renameNoticeLogged = true;
+  writeToLog(
+    "NOTICE: mcpcat has been renamed to agentcat (npm install agentcat). This package keeps working, but new features land only in agentcat. Guide: https://github.com/MCPCat/mcpcat-typescript-sdk/blob/main/MIGRATION.md",
+  );
+}
+
 /**
  * Integrates MCPCat analytics into an MCP server to track tool usage patterns and user interactions.
  *
@@ -164,6 +177,8 @@ function track(
   options: MCPCatOptions = {},
 ): any {
   try {
+    logRenameNoticeOnce();
+
     initDiagnostics({
       projectId,
       disabled: options.disableDiagnostics,

--- a/src/tests/deprecation-notice.test.ts
+++ b/src/tests/deprecation-notice.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as logging from "../modules/logging";
+import { track } from "../index.js";
+import { setupTestServerAndClient } from "./test-utils/client-server-factory";
+
+describe("deprecation notice", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs the rename notice on track(), once per process", async () => {
+    const spy = vi.spyOn(logging, "writeToLog").mockImplementation(() => {});
+    const first = await setupTestServerAndClient();
+    const second = await setupTestServerAndClient();
+    try {
+      track(first.server, "proj_test123");
+      track(second.server, "proj_test456");
+
+      const noticeCalls = spy.mock.calls.filter(([message]) =>
+        message.includes("mcpcat has been renamed to agentcat"),
+      );
+      expect(noticeCalls).toHaveLength(1);
+      expect(noticeCalls[0][0]).toContain("npm install agentcat");
+      expect(noticeCalls[0][0]).toContain("MIGRATION.md");
+    } finally {
+      await first.cleanup();
+      await second.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
Same team, same product, same cats — new name. Companion to #45: that PR renames the SDK to [`agentcat`](https://www.npmjs.com/package/agentcat); this one stages the **last release of the `mcpcat` package name**, pointing everyone who lands here at the new one.

`mcpcat@0.1.17` — no functional or dependency changes, just the rename notice on every surface npm gives us:

- 📖 README callout linking the migration guide (renders on the npmjs.com page)
- 🏷️ `[DEPRECATED — mcpcat is now agentcat: npm install agentcat]` package description
- 📝 One-time notice in `~/mcpcat.log` when `track()` runs — never stdout/stderr, which would corrupt STDIO MCP servers

After this ships, the registry entry will also be marked deprecated, so npm, pnpm, and yarn surface the rename at install time.

**Nothing you have deployed will break — ever.** The `mcpcat` package, `api.mcpcat.io`, and `MCPCAT_API_URL` stay alive permanently — migrate on your own schedule; new features land only in `agentcat`. Full steps (and a paste-into-your-coding-agent prompt): [MIGRATION.md](https://github.com/MCPCat/mcpcat-typescript-sdk/blob/rebrand/agentcat/MIGRATION.md)
