### PR TITLE
feat(redaction): pass field key, request, extra, and toolName context to redactSensitiveInformation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ import { initDiagnostics } from "./modules/diagnostics.js";
  * @param options.enableToolCallContext - Injects a "context" parameter to existing tools to capture user intent.
  * @param options.customContextDescription - Custom description for the injected context parameter. Only applies when enableToolCallContext is true. Use this to provide domain-specific guidance to LLMs about what context they should provide.
  * @param options.identify - Async function to identify users and attach custom data to their sessions.
- * @param options.redactSensitiveInformation - Function to redact sensitive data before sending to AgentCat.
+ * @param options.redactSensitiveInformation - Function to redact sensitive data before sending to AgentCat. Called once per string field in each event with `(text, context)`, where `context` contains `key` (the dotted path of the field, e.g. `"parameters.request.params.arguments.email"`), `request` and `extra` (the originating MCP request and handler extra, when one exists), and `toolName` (only set for tool call events).
  * @param options.eventTags - Callback invoked on every auto-captured event (tool calls, tool lists, initialize) to attach string key-value tags. Tags are intended to be indexed and queryable in the AgentCat dashboard — use them for structured metadata you'll want to filter or group by (e.g., trace IDs, environments, regions). Tags are validated client-side: keys must be ≤32 chars matching `[a-zA-Z0-9$_.:\- ]`, values must be strings ≤200 chars with no newlines, max 50 entries per event. Invalid entries are silently dropped with a warning logged to `~/agentcat.log`. If the callback throws or returns null, tags are omitted. Receives the same `(request, extra)` arguments as `identify`.
  * @param options.eventProperties - Callback invoked on every auto-captured event to attach flexible JSON metadata (device info, feature flags, nested context). No constraints beyond standard JSON types. If the callback throws or returns null, properties are omitted. Receives the same `(request, extra)` arguments as `identify`.
  * @param options.apiBaseUrl - Custom API base URL for sending events. Falls back to the `AGENTCAT_API_URL` environment variable if not set (then legacy `MCPCAT_API_URL`), then to the default `https://api.agentcat.com`.
@@ -108,7 +108,11 @@ import { initDiagnostics } from "./modules/diagnostics.js";
  * ```typescript
  * // With sensitive data redaction
  * agentcat.track(mcpServer, "proj_abc123xyz", {
- *   redactSensitiveInformation: async (text) => {
+ *   redactSensitiveInformation: async (text, context) => {
+ *     // Redact a specific field by key, for a specific tool
+ *     if (context?.toolName === "login" && context?.key?.endsWith(".password")) {
+ *       return "[REDACTED]";
+ *     }
  *     return text.replace(/api_key_\w+/g, "[REDACTED]");
  *   }
  * });
@@ -415,6 +419,7 @@ export type {
   AgentCatData,
   UserIdentity,
   RedactFunction,
+  RedactionContext,
   ExporterConfig,
   Exporter,
   CustomEventData,

--- a/src/modules/internal.ts
+++ b/src/modules/internal.ts
@@ -9,6 +9,7 @@ import { PublishEventRequestEventTypeEnum } from "agentcat-api";
 import { publishEvent } from "./eventQueue.js";
 import { writeToLog } from "./logging.js";
 import { validateTags } from "./validation.js";
+import { bindRedactionContext } from "./redaction.js";
 
 /**
  * Simple LRU cache for session identities.
@@ -157,7 +158,10 @@ export async function handleIdentify(
       extra: extra,
     },
     timestamp: new Date(),
-    redactionFn: data.options.redactSensitiveInformation,
+    redactionFn: bindRedactionContext(data.options.redactSensitiveInformation, {
+      request,
+      extra,
+    }),
   };
 
   try {

--- a/src/modules/redaction.ts
+++ b/src/modules/redaction.ts
@@ -1,4 +1,9 @@
-import { Event, RedactFunction, UnredactedEvent } from "../types.js";
+import {
+  Event,
+  RedactFunction,
+  RedactionContext,
+  UnredactedEvent,
+} from "../types.js";
 
 /**
  * Set of field names that should be protected from redaction.
@@ -47,7 +52,7 @@ async function redactStringsInObject(
     if (isProtected) {
       return obj;
     }
-    return await redactFn(obj);
+    return await redactFn(obj, { key: path });
   }
 
   // Handle arrays
@@ -92,6 +97,26 @@ async function redactStringsInObject(
 
   // For all other types (numbers, booleans, etc.), return as-is
   return obj;
+}
+
+/**
+ * Wraps the customer's redaction function so that every invocation receives the
+ * event-level context (request, extra, toolName) merged with the per-field
+ * context (key) supplied at redaction time.
+ *
+ * @param redactFn - The customer's redaction function, if configured
+ * @param context - Event-level context captured where the event is created
+ * @returns A RedactFunction with the context bound, or undefined
+ */
+export function bindRedactionContext(
+  redactFn: RedactFunction | undefined,
+  context: Omit<RedactionContext, "key">,
+): RedactFunction | undefined {
+  if (!redactFn) {
+    return undefined;
+  }
+  return (text, fieldContext) =>
+    redactFn(text, { ...fieldContext, ...context });
 }
 
 /**

--- a/src/modules/tools.ts
+++ b/src/modules/tools.ts
@@ -8,6 +8,7 @@ import { getServerTrackingData, handleIdentify } from "./internal.js";
 import { addContextParameterToTools } from "./context-parameters.js";
 import { publishEvent } from "./eventQueue.js";
 import { getServerSessionId } from "./session.js";
+import { bindRedactionContext } from "./redaction.js";
 import { PublishEventRequestEventTypeEnum } from "agentcat-api";
 import { getMCPCompatibleErrorMessage } from "./compatibility.js";
 
@@ -74,7 +75,10 @@ export function setupAgentCatTools(server: MCPServerLike): void {
         },
         eventType: PublishEventRequestEventTypeEnum.mcpToolsList,
         timestamp: new Date(),
-        redactionFn: data?.options.redactSensitiveInformation,
+        redactionFn: bindRedactionContext(
+          data?.options.redactSensitiveInformation,
+          { request, extra },
+        ),
       };
       if (data) {
         await handleIdentify(server, data, request, extra);

--- a/src/modules/tracing.ts
+++ b/src/modules/tracing.ts
@@ -18,6 +18,7 @@ import {
   resolveEventProperties,
 } from "./internal.js";
 import { getServerSessionId } from "./session.js";
+import { bindRedactionContext } from "./redaction.js";
 import { PublishEventRequestEventTypeEnum } from "agentcat-api";
 import { publishEvent } from "./eventQueue.js";
 import { getMCPCompatibleErrorMessage } from "./compatibility.js";
@@ -71,7 +72,10 @@ export function setupListToolsTracing(
         },
         eventType: PublishEventRequestEventTypeEnum.mcpToolsList,
         timestamp: new Date(),
-        redactionFn: data?.options.redactSensitiveInformation,
+        redactionFn: bindRedactionContext(
+          data?.options.redactSensitiveInformation,
+          { request, extra },
+        ),
       };
       if (data) {
         await handleIdentify(server, data, request, extra);
@@ -192,7 +196,10 @@ export function setupInitializeTracing(
             extra: extra,
           },
           timestamp: new Date(),
-          redactionFn: data.options.redactSensitiveInformation,
+          redactionFn: bindRedactionContext(
+            data.options.redactSensitiveInformation,
+            { request, extra },
+          ),
         };
 
         const resolvedTags = await resolveEventTags(data, request, extra);
@@ -285,7 +292,10 @@ export function setupToolCallTracing(server: MCPServerLike): void {
         },
         eventType: PublishEventRequestEventTypeEnum.mcpToolsCall,
         timestamp: new Date(),
-        redactionFn: data.options.redactSensitiveInformation,
+        redactionFn: bindRedactionContext(
+          data.options.redactSensitiveInformation,
+          { request, extra, toolName: request.params?.name },
+        ),
       };
 
       try {

--- a/src/modules/tracingV2.ts
+++ b/src/modules/tracingV2.ts
@@ -14,6 +14,7 @@ import {
   resolveEventProperties,
 } from "./internal.js";
 import { getServerSessionId } from "./session.js";
+import { bindRedactionContext } from "./redaction.js";
 import { PublishEventRequestEventTypeEnum } from "agentcat-api";
 import { publishEvent } from "./eventQueue.js";
 import { handleReportMissing } from "./tools.js";
@@ -307,7 +308,10 @@ function createToolsCallWrapper(
           parameters: { request, extra },
           eventType: PublishEventRequestEventTypeEnum.mcpToolsCall,
           timestamp: startTime,
-          redactionFn: data.options.redactSensitiveInformation,
+          redactionFn: bindRedactionContext(
+            data.options.redactSensitiveInformation,
+            { request, extra, toolName: request.params?.name },
+          ),
         };
 
         // Identify user session

--- a/src/tests/redaction.test.ts
+++ b/src/tests/redaction.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { redactEvent } from "../modules/redaction.js";
-import { UnredactedEvent, RedactFunction } from "../types.js";
+import { redactEvent, bindRedactionContext } from "../modules/redaction.js";
+import { UnredactedEvent, RedactFunction, RedactionContext } from "../types.js";
 import {
   setupTestServerAndClient,
   resetTodos,
@@ -30,7 +30,9 @@ describe("redactEvent", () => {
     const redacted = await redactEvent(event, mockRedactFn);
 
     expect(redacted.userIntent).toBe("[REDACTED-21]");
-    expect(mockRedactFn).toHaveBeenCalledWith("sensitive user intent");
+    expect(mockRedactFn).toHaveBeenCalledWith("sensitive user intent", {
+      key: "userIntent",
+    });
   });
 
   it("should not redact protected fields", async () => {
@@ -306,13 +308,16 @@ describe("redactEvent", () => {
     expect(redacted.otherData.nested.deeply.sensitive).toBe("[REDACTED-23]");
 
     // Verify the redact function was only called for non-protected content
-    expect(mockRedactFn).toHaveBeenCalledWith("this SHOULD be redacted");
-    expect(mockRedactFn).not.toHaveBeenCalledWith(
-      "this should NOT be redacted",
+    expect(mockRedactFn).toHaveBeenCalledWith("this SHOULD be redacted", {
+      key: "otherData.nested.deeply.sensitive",
+    });
+    const redactedTexts = (mockRedactFn as any).mock.calls.map(
+      (call: any[]) => call[0],
     );
-    expect(mockRedactFn).not.toHaveBeenCalledWith("array");
-    expect(mockRedactFn).not.toHaveBeenCalledWith("of");
-    expect(mockRedactFn).not.toHaveBeenCalledWith("strings");
+    expect(redactedTexts).not.toContain("this should NOT be redacted");
+    expect(redactedTexts).not.toContain("array");
+    expect(redactedTexts).not.toContain("of");
+    expect(redactedTexts).not.toContain("strings");
   });
 
   it("should create a new object without modifying the original", async () => {
@@ -383,6 +388,89 @@ describe("redactEvent", () => {
     expect(redacted.isError).toBe(false);
     expect(redacted.duration).toBe(1000);
     expect(redacted.timestamp).toBeInstanceOf(Date);
+  });
+
+  it("should pass the field key path to the redaction function", async () => {
+    const event: UnredactedEvent = {
+      sessionId: "ses_123",
+      userIntent: "top level",
+      parameters: {
+        request: {
+          params: {
+            arguments: { email: "user@example.com" },
+          },
+        },
+        items: ["first", "second"],
+      },
+    };
+
+    await redactEvent(event, mockRedactFn);
+
+    expect(mockRedactFn).toHaveBeenCalledWith("top level", {
+      key: "userIntent",
+    });
+    expect(mockRedactFn).toHaveBeenCalledWith("user@example.com", {
+      key: "parameters.request.params.arguments.email",
+    });
+    expect(mockRedactFn).toHaveBeenCalledWith("first", {
+      key: "parameters.items[0]",
+    });
+    expect(mockRedactFn).toHaveBeenCalledWith("second", {
+      key: "parameters.items[1]",
+    });
+  });
+});
+
+describe("bindRedactionContext", () => {
+  it("should return undefined when no redaction function is provided", () => {
+    expect(bindRedactionContext(undefined, { toolName: "my_tool" })).toBe(
+      undefined,
+    );
+  });
+
+  it("should merge event-level context with per-field context", async () => {
+    const userFn: RedactFunction = vi.fn(async () => "[REDACTED]");
+    const request = { params: { name: "my_tool", arguments: { a: "1" } } };
+    const extra = { sessionId: "session-1" } as any;
+
+    const bound = bindRedactionContext(userFn, {
+      request,
+      extra,
+      toolName: "my_tool",
+    });
+
+    await bound!("some text", { key: "parameters.a" });
+
+    expect(userFn).toHaveBeenCalledWith("some text", {
+      key: "parameters.a",
+      request,
+      extra,
+      toolName: "my_tool",
+    });
+  });
+
+  it("should provide event-level context even when redactEvent supplies the key", async () => {
+    const received: RedactionContext[] = [];
+    const userFn: RedactFunction = async (text, context) => {
+      if (context) received.push(context);
+      return "[REDACTED]";
+    };
+    const request = { params: { name: "my_tool" } };
+
+    const bound = bindRedactionContext(userFn, {
+      request,
+      toolName: "my_tool",
+    });
+    const event: UnredactedEvent = {
+      sessionId: "ses_123",
+      userIntent: "sensitive",
+    };
+
+    await redactEvent(event, bound!);
+
+    expect(received).toEqual([
+      { key: "userIntent", request, toolName: "my_tool", extra: undefined },
+    ]);
   });
 });
 
@@ -508,6 +596,56 @@ describe("redactEvent integration tests", () => {
     // The identify event includes actor info from sessionInfo
     expect(identifyEvent?.identifyActorGivenId).toBe("test-user-123");
     expect(identifyEvent?.identifyActorName).toBe("John Doe");
+
+    await eventCapture.stop();
+  });
+
+  it("should pass key, request, and toolName context to the redaction function on tool calls", async () => {
+    const eventCapture = new EventCapture();
+    await eventCapture.start();
+
+    const receivedContexts: RedactionContext[] = [];
+    const contextAwareRedactFn: RedactFunction = async (text, context) => {
+      if (context) receivedContexts.push(context);
+      return text;
+    };
+
+    track(server, "test-project", {
+      enableTracing: true,
+      redactSensitiveInformation: contextAwareRedactFn,
+    });
+
+    await client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "add_todo",
+          arguments: {
+            text: "Buy groceries",
+            context: "Adding a todo item",
+          },
+        },
+      },
+      CallToolResultSchema,
+    );
+
+    // Wait for events to be processed
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const toolCallContexts = receivedContexts.filter(
+      (c) => c.toolName === "add_todo",
+    );
+    expect(toolCallContexts.length).toBeGreaterThan(0);
+
+    // Every invocation carries a key path and the originating request
+    const textFieldContext = toolCallContexts.find(
+      (c) => c.key === "parameters.request.params.arguments.text",
+    );
+    expect(textFieldContext).toBeDefined();
+    expect(textFieldContext?.request?.params?.name).toBe("add_todo");
+    expect(textFieldContext?.request?.params?.arguments?.text).toBe(
+      "Buy groceries",
+    );
 
     await eventCapture.stop();
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,21 @@ export type RegisteredTool = {
   | { handler: ToolCallback; callback?: never }
 );
 
-export type RedactFunction = (text: string) => Promise<string>;
+export interface RedactionContext {
+  /** Dotted path of the field being redacted, e.g. "parameters.request.params.arguments.email" */
+  key?: string;
+  /** The MCP request that produced this event, when one exists */
+  request?: any;
+  /** The request handler extra (headers, sessionId, etc.), when available */
+  extra?: CompatibleRequestHandlerExtra;
+  /** The tool being called; only set for tool call events */
+  toolName?: string;
+}
+
+export type RedactFunction = (
+  text: string,
+  context?: RedactionContext,
+) => Promise<string>;
 
 export interface ExporterConfig {
   type: string;


### PR DESCRIPTION
## Summary

`redactSensitiveInformation` currently receives only the string value being redacted, so users can't make per-field or per-tool redaction decisions. This PR adds an optional second `context` argument:

```ts
redactSensitiveInformation: async (text, context) => {
  if (context?.toolName === "login" && context?.key?.endsWith(".password")) {
    return "[REDACTED]";
  }
  return text;
}
```

The new `RedactionContext` carries:
- `key` — dotted path of the field being redacted (e.g. `parameters.request.params.arguments.email`, with `[i]` for array indices)
- `request` / `extra` — the originating MCP request and handler extra, same values the `identify`, `eventTags`, and `eventProperties` callbacks receive
- `toolName` — `request.params.name`, set only for tool call events

## Implementation

- `RedactFunction` is now `(text, context?) => Promise<string>`; existing single-argument functions keep working unchanged.
- New `bindRedactionContext()` helper in `redaction.ts` wraps the user's function at each event-creation site (`tracing.ts`, `tracingV2.ts`, `tools.ts`, `internal.ts`), capturing `request`/`extra`/`toolName` via closure; `redactStringsInObject` supplies the per-field `key` it already tracked for protected-field checks.
- `RedactionContext` is exported from the package root.

## Testing

- Unit tests for key paths (nested objects and arrays) and `bindRedactionContext` merging.
- Integration test asserting a real `tools/call` delivers `key`, `request`, and `toolName` to the redaction function.
- Full suite passes (the pre-existing `esm-consumer` test failure is environmental — `pnpm` not on PATH), plus `tsc --noEmit` and `eslint`.