### PR TITLE
docs: add SDKs for other languages matrix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,27 @@ npm install agentcat
 
 To learn more about us, check us out [here](https://agentcat.com). For detailed guides visit our [documentation](https://docs.agentcat.com).
 
+## SDKs for other languages 🌍
+
+AgentCat ships the same one-line integration across the MCP ecosystem. If your server
+isn't written in TypeScript, you're in the right family — just the wrong repo.
+
+| Language       | Package                                                                | Status            |
+| -------------- | ---------------------------------------------------------------------- | ----------------- |
+| **TypeScript** | [`agentcat`](https://www.npmjs.com/package/agentcat)                   | ✅ Available      |
+| **Python**     | [`agentcat`](https://pypi.org/project/agentcat/)                       | ✅ Available      |
+| **Go**         | [`go.agentcat.com/sdk`](https://github.com/agentcathq/agentcat-go-sdk) | ✅ Available      |
+| **Java**       | `com.agentcat:agentcat`                                                | 🚧 In development |
+| **Ruby**       | `agentcat`                                                             | 🚧 In development |
+| **.NET**       | `AgentCat`                                                             | 🔜 Coming soon    |
+| **Rust**       | `agentcat-sdk`                                                         | 🔜 Coming soon    |
+| **PHP**        | `agentcat/sdk`                                                         | 🔜 Coming soon    |
+
+Package names for the upcoming SDKs are reserved on their registries, but those releases are
+placeholders that intentionally do nothing — don't wire them into a real server yet. Want one
+of them sooner? Open an issue or [tell us directly](https://meet.agentcat.com/meet); demand
+moves the roadmap.
+
 ## Why use AgentCat? 🤔
 
 AgentCat helps builders of MCP servers, Claude Connectors, and ChatGPT Plugins learn how to improve them by capturing any agents goals and detecting when they get stuck.


### PR DESCRIPTION
## Motivation

Developers arriving at this repo from a non-TypeScript MCP server had no way to tell whether AgentCat supported their language. The README described a TypeScript integration and nothing else, so the only way to find out was to search npm, PyPI, or the org's repo list one at a time.

AgentCat now has reserved package names across every registry it targets, and two ports are actively being built. This surfaces that roadmap where people actually look for it.

## What changed

Adds a **SDKs for other languages** section immediately after the install snippet — before the feature pitch, since "is my language supported?" is a routing question a reader needs answered first.

The matrix covers eight languages in three states:

| State | Languages |
| --- | --- |
| ✅ Available | TypeScript, Python, Go |
| 🚧 In development | Java, Ruby |
| 🔜 Coming soon | .NET, Rust, PHP |

Available SDKs link to their published packages. The upcoming ones deliberately **do not link** to their registry pages: their names are reserved, but the current releases are placeholders whose entry points throw immediately. Linking them would invite installs that fail confusingly. The section says this outright rather than leaving readers to discover it.

The section closes by inviting readers to open an issue or book a call if they want a particular language prioritized — the roadmap order is genuinely demand-driven, and this is a cheap signal channel.

## Behavior changes

None. Documentation only — no source, build, or published-package changes.

## Test plan

- `npx prettier --check README.md` passes
- Diff is a single 21-line insertion; no other part of the README is touched
- Table and links render correctly in GitHub-flavored Markdown