### PR TITLE
feat: sturdier session handles — issue IDs first, structured mcp_session status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcat",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Analytics tool for MCP (Model Context Protocol) servers and AI agents - tracks tool usage patterns and provides insights",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/engine/registry.ts
+++ b/src/engine/registry.ts
@@ -19,7 +19,7 @@ export function getInjectedParamsRegistry(
   return registries.get(server);
 }
 
-/** toolName set: tools whose declared outputSchema received _mcp_instructions. */
+/** toolName set: tools whose declared outputSchema received mcp_session. */
 export type OutputInjectionRegistry = Set<string>;
 
 const outputRegistries = new WeakMap<object, OutputInjectionRegistry>();

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { initDiagnostics } from "./modules/diagnostics.js";
  * @param options.enableToolCallContext - Injects a "context" parameter to existing tools to capture user intent. The context parameter is appended after the injected `session_id`/`agent_id` parameters.
  * @param options.customContextDescription - Custom description for the injected context parameter. Only applies when enableToolCallContext is true. Use this to provide domain-specific guidance to LLMs about what context they should provide.
  * @param options.enableAgentTracking - Injects an optional `agent_id` parameter so each agent (including every spawned subagent) is individually identifiable. Agent IDs are minted by the server on an agent's first call and echoed back on subsequent calls. Defaults to false (opt-in). The agent ID rides on events as the `agentcat_agent_id` tag.
- * @param options.resolveSessionId - Hook mode: supply your own session identifier per request (e.g. from your auth or workflow state) and AgentCat steps back — no `session_id` parameter is injected and no task instructions are prompted to the agent. The returned string is combined with your project ID into a deterministic KSUID, so the same identifier always maps to the same task. Return null to mint silently (avoid: the agent can never learn a silently minted ID). Receives the same `(request, extra)` arguments as `identify`.
+ * @param options.resolveSessionId - Hook mode: supply your own session identifier per request (e.g. from your auth or workflow state) and AgentCat steps back — no `session_id` parameter is injected and no issuance text is prepended to results. The returned string is combined with your project ID into a deterministic KSUID, so the same identifier always maps to the same task. Return null to mint silently (avoid: the agent can never learn a silently minted ID). Receives the same `(request, extra)` arguments as `identify`.
  * @param options.identify - Async function to identify the actor behind a tool call. Runs on every tool call; the result is stamped directly onto that call's event.
  * @param options.redactSensitiveInformation - Function to redact sensitive data before sending to AgentCat.
  * @param options.redactEvent - Event-level redaction hook invoked with the full event (inspect `resourceName`, `eventType`, `parameters`, `response`, etc.) before it is published. Return a modified event, or null to drop the event entirely. May be sync or async. Runs before `redactSensitiveInformation`, so it sees raw, unredacted values; the string-level hook, sanitization, and truncation still run on its output. The system-managed fields `id`, `sessionId`, `projectId`, `eventType`, and `timestamp` cannot be changed (`id` is assigned after redaction and is empty at hook time). If the hook throws, the event is dropped and the error is logged to `~/agentcat.log`.
@@ -328,7 +328,7 @@ function track(
  *   server,
  *   "proj_abc123xyz",
  *   {
- *     sessionId: "ses_abc123",
+ *     sessionId: "ses_2cOHEO0LYGADMzRvWTXXVbbgxgm",
  *     resourceName: "custom-action",
  *     parameters: { action: "user-feedback", rating: 5 },
  *     message: "User provided feedback"
@@ -340,7 +340,7 @@ function track(
  * ```typescript
  * // With a session ID string
  * await agentcat.publishCustomEvent(
- *   "ses_abc123",
+ *   "ses_2cOHEO0LYGADMzRvWTXXVbbgxgm",
  *   "proj_abc123xyz",
  *   {
  *     isError: true,

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -18,42 +18,59 @@ export const DEFAULT_DIAGNOSTICS_TOKEN =
 // agents echo handles back correctly. Do not reword casually.
 
 export const SESSION_ID_PARAM_DESCRIPTION =
-  "REQUIRED on every call after your first. This MCP server associates all of your tool calls for a given task using session_id; a call that arrives without it cannot be associated with your earlier work and is treated as the start of an unrelated task, disconnected from the original goal. Omit it on your first call only — the server will issue one in the _mcp_instructions field of the result (or a trailing [MCP INSTRUCTIONS] text block) — then echo that exact value on every later call. Never invent a value, and do not issue parallel tool calls until the server has issued your session_id. One session_id covers the whole goal from start to finish: when you spawn subagents you MUST give them this same session_id, or their work is severed from yours. Without session_id, this server does not function as intended.";
+  "Session continuity handle, one of two values: the ses_ ID issued for the task underway, or start. This server cannot link your calls between requests on its own, so session continuity travels in this parameter instead. If you were handed a session_id for this task — for example by the agent that spawned you — send that exact value from your first call. Otherwise send start on your first call; the server will issue an opaque correlation ID in the mcp_session field of the result, or in a text block at the start of the result beginning [session_id issued. Then send that exact ses_ value on every later call and hand it to any subagents working the same task. start always begins a new, unrelated task — never send it mid-task. If you send a value this server does not recognize, the result reports it: mcp_session.status of unrecognized, or a text block beginning [session_id unrecognized; re-send the ID issued for this task, or start if none was issued yet. Never invent a ses_ value.";
+
+// Machine-enforceable value contract for the injected session_id parameter,
+// advertised as the JSON Schema "pattern" of the injected property: the start
+// sentinel or a ses_ KSUID. Intentionally equal to the isValidSessionId shape
+// with the start alternative added — do not loosen or widen it.
+export const SESSION_ID_PARAM_PATTERN = "^(start|ses_[0-9A-Za-z]{27})$";
+
+// Sentinel an agent sends as session_id to explicitly begin a new, unrelated
+// task. Compared case-insensitively after trimming, and resolved exactly like
+// an omitted session_id: minted path, status issued, minted text block.
+export const SESSION_START_SENTINEL = "start";
 
 export const AGENT_ID_PARAM_DESCRIPTION =
-  "REQUIRED on every call, including your first. This MCP server distinguishes you from every other agent working this task using agent_id; a call that arrives without it cannot be attributed to you. Generate your own ID when you start work by joining three parts with '|': your model version, your harness name, and a short random suffix of 4-6 letters or digits chosen once. Example: opus-4.80-1m|claude-code|k3n9x. Send that same exact value on every call for your entire task; never change it mid-task. agent_id identifies you alone: a newly spawned subagent MUST generate its own instead of reusing its parent's. Without agent_id, this server does not function as intended.";
+  "Agent identity handle, required on every call including your first. This server cannot tell concurrent agents apart on its own; agent_id is how your calls are attributed to you. It is a self-chosen identifier in the spirit of a User-Agent string — join your model version, your harness name, and a short suffix of 4-6 letters or digits, with '|'. Example: opus-4.80-1m|claude-code|k3n9x. Choose the suffix once at the start of your task and send that same exact value on every call for the entire task; never change it mid-task, and a new task gets a fresh suffix. agent_id identifies exactly one agent and is never inherited: a subagent you spawn generates a new one rather than carrying yours, and if you were spawned by another agent, generate your own rather than reusing your parent's. A call without agent_id cannot be attributed to you.";
 
-export const AGENT_ID_PARAM_DESCRIPTION_HOOK_MODE =
-  "REQUIRED on every call, including your first. This MCP server distinguishes you from every other agent using agent_id; a call that arrives without it cannot be attributed to you. Generate your own ID when you start work by joining three parts with '|': your model version, your harness name, and a short random suffix of 4-6 letters or digits chosen once. Example: opus-4.80-1m|claude-code|k3n9x. Send that same exact value on every call for your entire task; never change it mid-task. agent_id identifies you alone: a newly spawned subagent MUST generate its own instead of reusing its parent's. Without agent_id, this server does not function as intended.";
+// Issuance and unrecognized-value text blocks, prepended as the first content
+// element so the id survives client-side truncation of long results.
+export const MINT_BACK_HEADER_ISSUED =
+  "[session_id issued — see this tool's session_id parameter description]";
 
-export const MINT_BACK_HEADER_SESSION =
-  "[MCP INSTRUCTIONS]: session_id issued.";
-export const MINT_BACK_HEADER_INVALID =
-  "[MCP INSTRUCTIONS]: session_id not recognized.";
-export const MINT_BACK_CLOSER =
-  "Without session_id, this server does not function as intended.";
-export const MINT_BACK_INVALID_LINE =
-  "  The session_id you sent was not issued by this server. Re-send the exact session_id this server issued to you earlier in this conversation. Never invent a value. If this server has not issued you a session_id yet, omit the parameter and one will be issued.";
+export const MINT_BACK_ISSUED_BODY =
+  "This is the first-call issuance described in this tool's session_id parameter description.";
+
+export const MINT_BACK_HEADER_UNRECOGNIZED =
+  "[session_id unrecognized — see this tool's session_id parameter description]";
+
+export const MINT_BACK_UNRECOGNIZED_BODY =
+  "The value sent was not issued by this server. Re-send the session_id issued earlier for this task; if none was issued yet, send start and one will be issued.";
 
 export const mintBackSessionLine = (sessionId: string): string =>
-  `  session_id=${sessionId} — required on every subsequent tool call`;
+  `session_id: ${sessionId}`;
 
 // ── Structured mint-back: mirrored into structuredContent ───────────────────
 // Wire key for the SDK-authored field injected into declared outputSchemas
-// and mirrored into structuredContent on every response.
-export const MCP_INSTRUCTIONS_KEY = "_mcp_instructions";
+// and mirrored as the first key of structuredContent whenever there is handle
+// state to report.
+export const MCP_SESSION_KEY = "mcp_session";
 
-export const mintBackConfirmed = (names: string[]): string =>
-  `[MCP INSTRUCTIONS]: ${names.join(" and ")} confirmed. Keep sending ${
-    names.length > 1 ? "these exact values" : "this exact value"
-  } on every call.`;
+export const MCP_SESSION_FIELD_DESCRIPTION =
+  "Session continuity and agent attribution state for this task, returned on completed responses that carry structured output. This server cannot link your calls between requests on its own, so session continuity travels here instead.";
 
-export const MCP_INSTRUCTIONS_FIELD_DESCRIPTION =
-  "Your handles for this task, confirmed by this MCP server on every response, and the instructions for echoing them on later calls. Read and follow.";
-export const MCP_INSTRUCTIONS_SESSION_ID_DESCRIPTION =
-  "Echo this exact value as the session_id argument on every subsequent tool call.";
-export const MCP_INSTRUCTIONS_AGENT_ID_DESCRIPTION =
-  "Your agent_id as this server received it. Keep sending this exact value on every call; a subagent must generate its own.";
+export const MCP_SESSION_FIELD_DESCRIPTION_HOOK_MODE =
+  "Agent attribution state for this task, returned on completed responses that carry structured output.";
+
+export const MCP_SESSION_SESSION_ID_DESCRIPTION =
+  "Opaque correlation ID for this task, issued by this server. Use this as the session_id argument of every later call, and hand it to any subagents working the same task. Absent when status is unrecognized; no replacement is issued in that response — recovery is described under status.";
+
+export const MCP_SESSION_AGENT_ID_DESCRIPTION =
+  "Present only when you sent agent_id on this call. Your agent_id, echoed as received. Continue sending this exact value on every call; it is never inherited — a subagent you spawn generates its own.";
+
+export const MCP_SESSION_STATUS_DESCRIPTION =
+  "issued: first call of a task; the session_id above was just created. active: the session_id you sent was accepted; keep sending it. unrecognized: the value sent was not issued by this server — re-send the one issued earlier for this task; if none was issued yet, send start to be issued a new one.";
 
 // ── Explicit handles: wire keys ─────────────────────────────────────────────
 export const META_CLIENT_INFO_KEY = "io.modelcontextprotocol/clientInfo";

--- a/src/modules/handle-injection.ts
+++ b/src/modules/handle-injection.ts
@@ -2,12 +2,14 @@ import { RegisteredTool } from "../types.js";
 import { SESSION_ID_PARAM, AGENT_ID_PARAM } from "./handles.js";
 import {
   SESSION_ID_PARAM_DESCRIPTION,
+  SESSION_ID_PARAM_PATTERN,
   AGENT_ID_PARAM_DESCRIPTION,
-  AGENT_ID_PARAM_DESCRIPTION_HOOK_MODE,
-  MCP_INSTRUCTIONS_KEY,
-  MCP_INSTRUCTIONS_FIELD_DESCRIPTION,
-  MCP_INSTRUCTIONS_SESSION_ID_DESCRIPTION,
-  MCP_INSTRUCTIONS_AGENT_ID_DESCRIPTION,
+  MCP_SESSION_KEY,
+  MCP_SESSION_FIELD_DESCRIPTION,
+  MCP_SESSION_FIELD_DESCRIPTION_HOOK_MODE,
+  MCP_SESSION_SESSION_ID_DESCRIPTION,
+  MCP_SESSION_AGENT_ID_DESCRIPTION,
+  MCP_SESSION_STATUS_DESCRIPTION,
 } from "./constants.js";
 import { GET_MORE_TOOLS_NAME } from "./tools.js";
 import { writeToLog } from "./logging.js";
@@ -38,6 +40,23 @@ function recordInjected(
   else registry.set(toolName, new Set([param]));
 }
 
+/**
+ * Adds a param to the schema's required array: created if absent, appended
+ * without duplicating, customer entries never removed or reordered.
+ * Requiredness rides injection exactly — only a param AgentCat injected on
+ * this tool is ever added — and enforcement stays soft: callWrap tolerates
+ * omission (session minted / event without agent identity), so the flag
+ * drives schema-aware clients only.
+ */
+function addToRequired(schema: Record<string, any>, param: string): void {
+  const required = schema.required;
+  if (Array.isArray(required)) {
+    if (!required.includes(param)) required.push(param);
+  } else {
+    schema.required = [param];
+  }
+}
+
 export interface HandleInjectionOptions {
   injectSessionId: boolean; // false in hook mode
   injectAgentId: boolean; // false when enableAgentTracking is false
@@ -52,7 +71,8 @@ export interface HandleInjectionOptions {
 }
 
 /**
- * Injects optional session_id/agent_id into each tool's JSON Schema (post-Zod).
+ * Injects session_id/agent_id into each tool's JSON Schema (post-Zod), both
+ * schema-required with soft enforcement (see addToRequired).
  * Order: customer params, session_id, agent_id — context is appended afterwards
  * by addContextParameterToTools, so this MUST run first. Unlike the context
  * injector, get_more_tools is NOT exempt: its calls publish events, so it
@@ -140,8 +160,10 @@ function addHandleParametersToTool(
       properties[SESSION_ID_PARAM] = {
         type: "string",
         description: SESSION_ID_PARAM_DESCRIPTION,
+        pattern: SESSION_ID_PARAM_PATTERN,
       };
       recordInjected(registry, toolName, SESSION_ID_PARAM);
+      addToRequired(modifiedTool.inputSchema, SESSION_ID_PARAM);
     }
   }
 
@@ -153,45 +175,37 @@ function addHandleParametersToTool(
     } else {
       properties[AGENT_ID_PARAM] = {
         type: "string",
-        // Hook mode has no session_id param anywhere; never reference one the
-        // agent cannot see.
-        description: opts.injectSessionId
-          ? AGENT_ID_PARAM_DESCRIPTION
-          : AGENT_ID_PARAM_DESCRIPTION_HOOK_MODE,
+        // One description for both modes: the copy never references the
+        // session_id parameter, so it reads the same with or without one.
+        description: AGENT_ID_PARAM_DESCRIPTION,
       };
       recordInjected(registry, toolName, AGENT_ID_PARAM);
-      // agent_id is self-chosen by the agent and schema-required. Enforcement
-      // is soft: callWrap tolerates omission (event published without agent
-      // identity) — the required flag drives client-side compliance only.
-      const required = modifiedTool.inputSchema.required;
-      if (Array.isArray(required)) {
-        if (!required.includes(AGENT_ID_PARAM)) required.push(AGENT_ID_PARAM);
-      } else {
-        modifiedTool.inputSchema.required = [AGENT_ID_PARAM];
-      }
+      // agent_id is self-chosen by the agent (no pattern to advertise), and
+      // schema-required like session_id above — see addToRequired for the
+      // soft-enforcement contract.
+      addToRequired(modifiedTool.inputSchema, AGENT_ID_PARAM);
     }
   }
 
-  // session_id is never required — omission is the minting signal. agent_id
-  // (self-chosen, injected above) is the exception.
   if (outputRegistry) {
-    addInstructionsToOutputSchema(modifiedTool, opts, outputRegistry, toolName);
+    addMcpSessionToOutputSchema(modifiedTool, opts, outputRegistry, toolName);
   }
   return modifiedTool;
 }
 
 /**
- * Injects the optional _mcp_instructions property into a declared plain-object
+ * Injects the optional mcp_session property into a declared plain-object
  * outputSchema so validating clients accept the mirrored field. The MCP TS
  * client ajv-validates structuredContent against the listed schema, and
  * zod-to-json-schema emits additionalProperties: false for plain z.object —
  * an undeclared key would fail the whole result, so declaration is what makes
  * mirroring safe. Composed schemas (oneOf/allOf/anyOf) have no single
  * properties bag to extend and are skipped, same policy as the input side.
- * Sub-properties mirror the modes: no session_id in hook mode, no agent_id when
- * tracking is off — copy never references a parameter the agent cannot see.
+ * Sub-properties mirror the modes: no session_id or status in hook mode, no
+ * agent_id when tracking is off — every response state the schema
+ * pre-announces is one the agent can actually receive.
  */
-function addInstructionsToOutputSchema(
+function addMcpSessionToOutputSchema(
   tool: RegisteredTool,
   opts: HandleInjectionOptions,
   outputRegistry: OutputInjectionRegistry,
@@ -201,15 +215,15 @@ function addInstructionsToOutputSchema(
   if (!schema) return;
   if (schema.oneOf || schema.allOf || schema.anyOf) {
     writeToLog(
-      `WARN: Tool "${toolName}" has complex outputSchema (oneOf/allOf/anyOf). Skipping ${MCP_INSTRUCTIONS_KEY} injection; mint-back stays content-only for this tool.`,
+      `WARN: Tool "${toolName}" has complex outputSchema (oneOf/allOf/anyOf). Skipping ${MCP_SESSION_KEY} injection; mint-back stays content-only for this tool.`,
     );
     return;
   }
   const copy = JSON.parse(JSON.stringify(schema));
   if (!copy.properties) copy.properties = {};
-  if (copy.properties[MCP_INSTRUCTIONS_KEY]) {
+  if (copy.properties[MCP_SESSION_KEY]) {
     writeToLog(
-      `WARN: Tool "${toolName}" already declares '${MCP_INSTRUCTIONS_KEY}' in outputSchema. Skipping injection.`,
+      `WARN: Tool "${toolName}" already declares '${MCP_SESSION_KEY}' in outputSchema. Skipping injection.`,
     );
     return;
   }
@@ -217,19 +231,27 @@ function addInstructionsToOutputSchema(
   if (opts.injectSessionId) {
     subProperties[SESSION_ID_PARAM] = {
       type: "string",
-      description: MCP_INSTRUCTIONS_SESSION_ID_DESCRIPTION,
+      description: MCP_SESSION_SESSION_ID_DESCRIPTION,
     };
   }
   if (opts.injectAgentId) {
     subProperties[AGENT_ID_PARAM] = {
       type: "string",
-      description: MCP_INSTRUCTIONS_AGENT_ID_DESCRIPTION,
+      description: MCP_SESSION_AGENT_ID_DESCRIPTION,
     };
   }
-  subProperties.instructions = { type: "string" };
-  copy.properties[MCP_INSTRUCTIONS_KEY] = {
+  if (opts.injectSessionId) {
+    subProperties.status = {
+      type: "string",
+      enum: ["issued", "active", "unrecognized"],
+      description: MCP_SESSION_STATUS_DESCRIPTION,
+    };
+  }
+  copy.properties[MCP_SESSION_KEY] = {
     type: "object",
-    description: MCP_INSTRUCTIONS_FIELD_DESCRIPTION,
+    description: opts.injectSessionId
+      ? MCP_SESSION_FIELD_DESCRIPTION
+      : MCP_SESSION_FIELD_DESCRIPTION_HOOK_MODE,
     properties: subProperties,
   };
   (tool as any).outputSchema = copy;

--- a/src/modules/handles.ts
+++ b/src/modules/handles.ts
@@ -1,13 +1,13 @@
 import { createHash } from "crypto";
 import KSUID from "../thirdparty/ksuid/index.js";
 import {
-  MINT_BACK_HEADER_SESSION,
-  MINT_BACK_HEADER_INVALID,
-  MINT_BACK_CLOSER,
-  MINT_BACK_INVALID_LINE,
+  MINT_BACK_HEADER_ISSUED,
+  MINT_BACK_ISSUED_BODY,
+  MINT_BACK_HEADER_UNRECOGNIZED,
+  MINT_BACK_UNRECOGNIZED_BODY,
   mintBackSessionLine,
-  MCP_INSTRUCTIONS_KEY,
-  mintBackConfirmed,
+  SESSION_START_SENTINEL,
+  MCP_SESSION_KEY,
   AGENTCAT_TAG_AGENT_ID,
   AGENTCAT_TAG_SESSION_SOURCE,
   AGENTCAT_TAG_AGENT_SOURCE,
@@ -88,69 +88,71 @@ export interface HandleResolution {
 }
 
 /**
- * Builds the [MCP INSTRUCTIONS] block for a task minted on this call, or the
- * correction block when the agent sent a session_id this server never
- * issued. Returns null when nothing needs announcing. Task instructions
- * never appear in hook mode — even when a hook-null forced a silent mint.
- * agent_id is self-chosen by the agent and never announced here.
+ * Builds the issuance block for a task minted on this call, or the
+ * unrecognized-value block when the agent sent a session_id this server never
+ * issued. Returns null when nothing needs announcing. The block never appears
+ * in hook mode — even when a hook-null forced a silent mint. agent_id is
+ * self-chosen by the agent and never announced here.
  *
  * @param res - The resolved handles for this call
- * @returns The instruction block, or null when nothing needs saying
+ * @returns The text block, or null when nothing needs saying
  */
 export function buildMintBackText(res: HandleResolution): string | null {
   if (res.hookMode) return null;
   if (res.sessionSource === "minted") {
     return [
-      MINT_BACK_HEADER_SESSION,
+      MINT_BACK_HEADER_ISSUED,
       mintBackSessionLine(res.sessionId),
-      MINT_BACK_CLOSER,
+      MINT_BACK_ISSUED_BODY,
     ].join("\n");
   }
   if (res.sessionSource === "invalid") {
-    return [
-      MINT_BACK_HEADER_INVALID,
-      MINT_BACK_INVALID_LINE,
-      MINT_BACK_CLOSER,
-    ].join("\n");
+    return [MINT_BACK_HEADER_UNRECOGNIZED, MINT_BACK_UNRECOGNIZED_BODY].join(
+      "\n",
+    );
   }
   return null;
 }
 
 /**
- * Appends the mint-back block to a CallToolResult. Applies to isError results
- * too (the retry after an error must carry the same task). Only requirement:
- * an array `content`. Never mutates the input.
+ * Prepends the mint-back block to a CallToolResult as the first content
+ * element — IDs at the end of long responses can be truncated away by
+ * clients. Applies to isError results too (the retry after an error must
+ * carry the same task). Only requirement: an array `content`. Never mutates
+ * the input.
  *
- * @param result - The tool result to append to
- * @param text - The mint-back block to append as a text content block
+ * @param result - The tool result to prepend to
+ * @param text - The mint-back block to prepend as a text content block
  * @returns A shallow copy carrying the extra block, or the input untouched
  */
 export function appendMintBack(result: any, text: string): any {
   if (!result || typeof result !== "object" || !Array.isArray(result.content)) {
     return result;
   }
-  return { ...result, content: [...result.content, { type: "text", text }] };
+  return { ...result, content: [{ type: "text", text }, ...result.content] };
 }
 
 export interface StructuredMintBack {
   session_id?: string;
   agent_id?: string;
-  instructions: string;
+  status?: "issued" | "active" | "unrecognized";
 }
 
 /**
  * Builds the structured mint-back mirrored into structuredContent. Unlike
- * buildMintBackText (task-mint announcements only), this is persistent handle
- * state, present on EVERY response — supplied handles are re-confirmed, so an
- * agent can re-read its own session_id/agent_id mid-conversation. Handles the
- * agent cannot echo are never named: no session_id in hook mode, none for
- * "invalid" (correcting, not confirming — no replacement is issued), none for
- * "foreign" (that parameter is the customer's, not ours to speak about), and
- * no agent_id when the agent didn't supply one. Returns null when nothing is
- * echoable.
+ * buildMintBackText (issuance announcements only), this is persistent handle
+ * state, present on every response with something to report — supplied
+ * handles are re-echoed, so an agent can re-read its own session_id/agent_id
+ * mid-conversation. In prompted mode the session state is a machine-readable
+ * status: "issued" (just created, session_id alongside), "active" (the value
+ * sent was accepted, session_id alongside), or "unrecognized" (no session_id
+ * — no replacement is issued). Handles the agent cannot echo are never named:
+ * no session_id or status in hook mode, none for "foreign" (that parameter is
+ * the customer's, not ours to speak about), and no agent_id when the agent
+ * didn't supply one. Returns null when the payload would be empty.
  *
  * Suppression is per-handle, not per-response: on a foreign tool AgentCat
- * still injected agent_id, so that half stays ours to confirm even though
+ * still injected agent_id, so that half stays ours to echo even though
  * session_id is not.
  *
  * @param res - The resolved handles for this call
@@ -159,28 +161,28 @@ export interface StructuredMintBack {
 export function buildStructuredMintBack(
   res: HandleResolution,
 ): StructuredMintBack | null {
-  const sessionEchoable =
-    !res.hookMode &&
-    res.sessionSource !== "invalid" &&
-    res.sessionSource !== "foreign";
-  const names: string[] = [];
-  if (sessionEchoable) names.push(SESSION_ID_PARAM);
-  if (res.agentId) names.push(AGENT_ID_PARAM);
-
-  const text = buildMintBackText(res);
-  if (names.length === 0 && !text) return null;
-
-  return {
-    ...(sessionEchoable ? { [SESSION_ID_PARAM]: res.sessionId } : {}),
-    ...(res.agentId ? { [AGENT_ID_PARAM]: res.agentId } : {}),
-    instructions: text ?? mintBackConfirmed(names),
-  };
+  const sessionOurs = !res.hookMode && res.sessionSource !== "foreign";
+  const mint: StructuredMintBack = {};
+  if (sessionOurs && res.sessionSource !== "invalid") {
+    mint[SESSION_ID_PARAM] = res.sessionId;
+  }
+  if (res.agentId) mint[AGENT_ID_PARAM] = res.agentId;
+  if (sessionOurs) {
+    mint.status =
+      res.sessionSource === "minted"
+        ? "issued"
+        : res.sessionSource === "invalid"
+          ? "unrecognized"
+          : "active";
+  }
+  return Object.keys(mint).length > 0 ? mint : null;
 }
 
 /**
- * Mirrors the structured mint-back into result.structuredContent. Requires a
- * plain-object structuredContent to extend; an already-present key is customer
- * data and always wins. Never mutates the input.
+ * Mirrors the structured mint-back into result.structuredContent as its FIRST
+ * key, so the handle state survives client-side truncation of long results.
+ * Requires a plain-object structuredContent to extend; an already-present key
+ * is customer data and always wins. Never mutates the input.
  *
  * @param result - The tool result to mirror into
  * @param mint - The structured mint-back payload
@@ -192,10 +194,10 @@ export function mirrorStructuredMintBack(
 ): any {
   const sc = result?.structuredContent;
   if (!sc || typeof sc !== "object" || Array.isArray(sc)) return result;
-  if (MCP_INSTRUCTIONS_KEY in sc) return result;
+  if (MCP_SESSION_KEY in sc) return result;
   return {
     ...result,
-    structuredContent: { ...sc, [MCP_INSTRUCTIONS_KEY]: mint },
+    structuredContent: { [MCP_SESSION_KEY]: mint, ...sc },
   };
 }
 
@@ -270,8 +272,11 @@ export function resolveHandles(
     sessionId = "";
     sessionSource = "foreign";
   } else {
+    // The start sentinel is checked before shape validation, and only here —
+    // on the path where the session param is ours. A foreign customer-owned
+    // value is never interpreted as a sentinel.
     const supplied = extractHandle(args, SESSION_ID_PARAM);
-    if (supplied) {
+    if (supplied && supplied.toLowerCase() !== SESSION_START_SENTINEL) {
       if (isValidSessionId(supplied)) {
         sessionId = supplied;
         sessionSource = "supplied";
@@ -282,6 +287,9 @@ export function resolveHandles(
         sessionSource = "invalid";
       }
     } else {
+      // Absent, empty, or the explicit start sentinel: begin a new task.
+      // Omission keeps minting so stale schemas and scripted callers that
+      // never learned the parameter cannot error.
       sessionId = newSessionId();
       sessionSource = "minted";
     }

--- a/src/tests/basic-server.test.ts
+++ b/src/tests/basic-server.test.ts
@@ -202,7 +202,7 @@ describe("Basic Server Test", () => {
       );
 
       expect(result).toBeDefined();
-      expect(result.content[0].text).toContain("test data");
+      expect(result.content[1].text).toContain("test data");
     } finally {
       await cleanup();
     }
@@ -273,7 +273,7 @@ describe("Basic Server Test", () => {
       );
 
       expect(result).toBeDefined();
-      expect(result.content[0].text).toBe("8");
+      expect(result.content[1].text).toBe("8");
     } finally {
       await cleanup();
     }
@@ -517,7 +517,7 @@ describe("Basic Server Test", () => {
       );
 
       expect(addResult).toBeDefined();
-      expect(addResult.content[0].text).toBe("8");
+      expect(addResult.content[1].text).toBe("8");
 
       const calcResult = await client.request(
         {
@@ -536,7 +536,7 @@ describe("Basic Server Test", () => {
       );
 
       expect(calcResult).toBeDefined();
-      expect(calcResult.content[0].text).toBe("28");
+      expect(calcResult.content[1].text).toBe("28");
     } finally {
       await clientTransport.close?.();
       await serverTransport.close?.();

--- a/src/tests/constants.test.ts
+++ b/src/tests/constants.test.ts
@@ -4,9 +4,15 @@ import {
   AGENTCAT_SOURCE,
   DIAGNOSTICS_SCOPE_NAME,
   SESSION_ID_PARAM_DESCRIPTION,
+  SESSION_ID_PARAM_PATTERN,
+  SESSION_START_SENTINEL,
   AGENT_ID_PARAM_DESCRIPTION,
-  AGENT_ID_PARAM_DESCRIPTION_HOOK_MODE,
-  MCP_INSTRUCTIONS_KEY,
+  MCP_SESSION_KEY,
+  MCP_SESSION_STATUS_DESCRIPTION,
+  MINT_BACK_HEADER_ISSUED,
+  MINT_BACK_ISSUED_BODY,
+  MINT_BACK_HEADER_UNRECOGNIZED,
+  MINT_BACK_UNRECOGNIZED_BODY,
 } from "../modules/constants.js";
 
 describe("brand constants (wire literals)", () => {
@@ -21,21 +27,70 @@ describe("brand constants (wire literals)", () => {
   it("uses the agentcat diagnostics scope name", () => {
     expect(DIAGNOSTICS_SCOPE_NAME).toBe("agentcat-diagnostics");
   });
+
+  it("mirrors under the mcp_session key", () => {
+    expect(MCP_SESSION_KEY).toBe("mcp_session");
+  });
 });
 
 describe("handle param descriptions name the delivery channel", () => {
-  it("session_id describes server-issued delivery via _mcp_instructions", () => {
-    expect(SESSION_ID_PARAM_DESCRIPTION).toContain(MCP_INSTRUCTIONS_KEY);
-    expect(SESSION_ID_PARAM_DESCRIPTION).toContain("[MCP INSTRUCTIONS]");
+  it("session_id pre-announces both delivery channels and both text headers", () => {
+    expect(SESSION_ID_PARAM_DESCRIPTION).toContain(MCP_SESSION_KEY);
+    expect(SESSION_ID_PARAM_DESCRIPTION).toContain(
+      "a text block at the start of the result beginning [session_id issued",
+    );
+    expect(SESSION_ID_PARAM_DESCRIPTION).toContain(
+      "a text block beginning [session_id unrecognized",
+    );
+    expect(MINT_BACK_HEADER_ISSUED).toMatch(/^\[session_id issued/);
+    expect(MINT_BACK_HEADER_UNRECOGNIZED).toMatch(/^\[session_id unrecognized/);
   });
 
   it("agent_id describes self-chosen generation, not server delivery", () => {
-    for (const description of [
-      AGENT_ID_PARAM_DESCRIPTION,
-      AGENT_ID_PARAM_DESCRIPTION_HOOK_MODE,
-    ]) {
-      expect(description).toContain("generate its own");
-      expect(description).toContain("opus-4.80-1m|claude-code|k3n9x");
-    }
+    expect(AGENT_ID_PARAM_DESCRIPTION).toContain(
+      "opus-4.80-1m|claude-code|k3n9x",
+    );
+    expect(AGENT_ID_PARAM_DESCRIPTION).toContain("never inherited");
+    expect(AGENT_ID_PARAM_DESCRIPTION).toContain("generates a new one");
+    expect(AGENT_ID_PARAM_DESCRIPTION).not.toContain("the server will issue");
+  });
+});
+// Byte-exact pins for the v4 copy: the session_id value contract (start | ses_)
+// and every string that teaches it. A drifted character here is a wire change.
+describe("v4 copy pins (byte-exact)", () => {
+  it("pins SESSION_ID_PARAM_DESCRIPTION", () => {
+    expect(SESSION_ID_PARAM_DESCRIPTION).toBe(
+      "Session continuity handle, one of two values: the ses_ ID issued for the task underway, or start. This server cannot link your calls between requests on its own, so session continuity travels in this parameter instead. If you were handed a session_id for this task — for example by the agent that spawned you — send that exact value from your first call. Otherwise send start on your first call; the server will issue an opaque correlation ID in the mcp_session field of the result, or in a text block at the start of the result beginning [session_id issued. Then send that exact ses_ value on every later call and hand it to any subagents working the same task. start always begins a new, unrelated task — never send it mid-task. If you send a value this server does not recognize, the result reports it: mcp_session.status of unrecognized, or a text block beginning [session_id unrecognized; re-send the ID issued for this task, or start if none was issued yet. Never invent a ses_ value.",
+    );
+  });
+
+  it("pins MCP_SESSION_STATUS_DESCRIPTION", () => {
+    expect(MCP_SESSION_STATUS_DESCRIPTION).toBe(
+      "issued: first call of a task; the session_id above was just created. active: the session_id you sent was accepted; keep sending it. unrecognized: the value sent was not issued by this server — re-send the one issued earlier for this task; if none was issued yet, send start to be issued a new one.",
+    );
+  });
+
+  it("pins MINT_BACK_ISSUED_BODY", () => {
+    expect(MINT_BACK_ISSUED_BODY).toBe(
+      "This is the first-call issuance described in this tool's session_id parameter description.",
+    );
+  });
+
+  it("pins MINT_BACK_UNRECOGNIZED_BODY", () => {
+    expect(MINT_BACK_UNRECOGNIZED_BODY).toBe(
+      "The value sent was not issued by this server. Re-send the session_id issued earlier for this task; if none was issued yet, send start and one will be issued.",
+    );
+  });
+
+  it("pins the session_id value-contract constants", () => {
+    expect(SESSION_ID_PARAM_PATTERN).toBe("^(start|ses_[0-9A-Za-z]{27})$");
+    expect(SESSION_START_SENTINEL).toBe("start");
+    // The pattern is exactly the isValidSessionId shape plus the sentinel.
+    const re = new RegExp(SESSION_ID_PARAM_PATTERN);
+    expect(re.test(SESSION_START_SENTINEL)).toBe(true);
+    expect(re.test("ses_" + "a".repeat(27))).toBe(true);
+    expect(re.test("ses_" + "a".repeat(25))).toBe(false);
+    expect(re.test("restart")).toBe(false);
+    expect(re.test("START")).toBe(false); // case handling lives in resolution
   });
 });

--- a/src/tests/context-parameters.test.ts
+++ b/src/tests/context-parameters.test.ts
@@ -162,7 +162,7 @@ describe("Context Parameters", () => {
         CallToolResultSchema,
       );
 
-      expect(result.content[0].text).toContain("Added todo");
+      expect(result.content[1].text).toContain("Added todo");
 
       // Wait a bit for the event to be processed
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -223,7 +223,7 @@ describe("Context Parameters", () => {
         CallToolResultSchema,
       );
 
-      expect(result.content[0].text).toContain("Completed todo");
+      expect(result.content[1].text).toContain("Completed todo");
 
       // Wait for events to be processed
       await new Promise((resolve) => setTimeout(resolve, 50));

--- a/src/tests/custom-context-description.test.ts
+++ b/src/tests/custom-context-description.test.ts
@@ -154,7 +154,7 @@ describe("Custom Context Description", () => {
       CallToolResultSchema,
     );
 
-    expect(result.content[0].text).toContain("Added todo");
+    expect(result.content[1].text).toContain("Added todo");
 
     // Wait for events to be processed
     await new Promise((resolve) => setTimeout(resolve, 50));

--- a/src/tests/e2e-http/sse-smoke-v1.test.ts
+++ b/src/tests/e2e-http/sse-smoke-v1.test.ts
@@ -26,7 +26,7 @@ import { scenarioConfig } from "./scenario-types.js";
 import { buildV1Toolkit, type ToolSink } from "./toolkit.js";
 import {
   AGENTCAT_TAG_SESSION_SOURCE,
-  MINT_BACK_HEADER_SESSION,
+  MINT_BACK_HEADER_ISSUED,
 } from "../../modules/constants.js";
 
 interface SseInstance {
@@ -134,7 +134,7 @@ describe("e2e-http v1 SSE smoke (stateful, enableJsonResponse: false)", () => {
       });
       const mintBack = mintBackOf(result);
       expect(mintBack).toBeDefined();
-      expect(mintBack).toContain(MINT_BACK_HEADER_SESSION);
+      expect(mintBack).toContain(MINT_BACK_HEADER_ISSUED);
       const sessionId = handleFrom(mintBack!, "session_id");
       expect(sessionId).toMatch(/^ses_/);
 

--- a/src/tests/e2e-http/v1-matrix.test.ts
+++ b/src/tests/e2e-http/v1-matrix.test.ts
@@ -41,7 +41,8 @@ import {
   AGENTCAT_TAG_SESSION_SOURCE,
   DEFAULT_CONTEXT_PARAMETER_DESCRIPTION,
   META_PROTOCOL_VERSION_KEY,
-  MINT_BACK_HEADER_SESSION,
+  MINT_BACK_HEADER_ISSUED,
+  SESSION_ID_PARAM_PATTERN,
 } from "../../modules/constants.js";
 
 const lanes: Lane[] = [laneById("v1-stateful"), laneById("v1-stateless")];
@@ -69,17 +70,23 @@ const scenarios: Scenario[] = [
         DEFAULT_CONTEXT_PARAMETER_DESCRIPTION,
       );
       expect(echo.inputSchema.properties.session_id).toBeDefined();
-      // Handles are never required — omission is the minting signal.
-      expect(echo.inputSchema.required ?? []).not.toContain("session_id");
+      // The injected session_id is schema-required and advertises the
+      // start|ses_ value contract as a pattern.
+      expect(echo.inputSchema.required).toContain("session_id");
+      expect(echo.inputSchema.properties.session_id.pattern).toBe(
+        SESSION_ID_PARAM_PATTERN,
+      );
 
-      // Call with context but no session_id → SDK mints and announces the handle.
+      // Omission tolerance: requiredness is enforced by schema-aware clients
+      // only, so a call without session_id still mints and announces the
+      // handle.
       const result = await client.callTool({
         name: "echo",
         arguments: { msg: "hi", context: "e2e smoke intent" },
       });
       const mintBack = mintBackOf(result);
       expect(mintBack).toBeDefined();
-      expect(mintBack).toContain(MINT_BACK_HEADER_SESSION);
+      expect(mintBack).toContain(MINT_BACK_HEADER_ISSUED);
       const sessionId = handleFrom(mintBack!, "session_id");
       expect(sessionId).toMatch(/^ses_/);
 
@@ -183,8 +190,8 @@ const scenarios: Scenario[] = [
         name: "get_more_tools",
         arguments: { context: missing },
       });
-      expect(result.content[0].text).toContain("Unfortunately");
-      expect(result.content[0].text).toContain(
+      expect(result.content[1].text).toContain("Unfortunately");
+      expect(result.content[1].text).toContain(
         "we have shown you the full tool list",
       );
       const block = mintBackOf(result)!;
@@ -197,9 +204,7 @@ const scenarios: Scenario[] = [
       expect(event.userIntent).toBe(missing);
       expect(event.sessionId).toBe(handleFrom(block, "session_id"));
       // Mint-back is wire-only — never recorded on the published event.
-      expect(JSON.stringify(event.response)).not.toContain(
-        "[MCP INSTRUCTIONS]",
-      );
+      expect(JSON.stringify(event.response)).not.toContain("[session_id");
     },
   },
 
@@ -264,26 +269,29 @@ const scenarios: Scenario[] = [
       expect(structured.inputSchema.properties.agent_id).toBeDefined();
       expect(structured.inputSchema.properties.session_id).toBeDefined();
       expect(structured.inputSchema.required).toContain("agent_id");
+      expect(structured.inputSchema.required).toContain("session_id");
       const gmt = findTool(tools, "get_more_tools")!;
       expect(gmt.inputSchema.properties.agent_id).toBeDefined();
       expect(gmt.inputSchema.required).toContain("agent_id");
+      expect(gmt.inputSchema.required).toContain("session_id");
 
       // structured declares an outputSchema, so the mirror rides
       // structuredContent — and the v1 client ajv-validates it against the
-      // injected outputSchema it just listed.
+      // injected outputSchema it just listed. First call sends start.
       const result = await client.callTool({
         name: "structured",
-        arguments: { msg: "hi", context: "agent minting" },
+        arguments: { msg: "hi", context: "agent minting", session_id: "start" },
       });
       const block = mintBackOf(result)!;
-      expect(block).toContain(MINT_BACK_HEADER_SESSION);
+      expect(block).toContain(MINT_BACK_HEADER_ISSUED);
       expect(block).not.toContain("agent_id");
       const sessionId = handleFrom(block, "session_id");
       expect(sessionId).toMatch(/^ses_/);
 
-      const mirror = result.structuredContent._mcp_instructions;
+      const mirror = result.structuredContent.mcp_session;
       expect(mirror.session_id).toBe(sessionId);
       expect(mirror.agent_id).toBeUndefined();
+      expect(mirror.status).toBe("issued");
       expect(result.structuredContent.echoed).toBe("hi");
 
       const [event] = await waitForEvents(capture, 1);
@@ -304,10 +312,14 @@ const scenarios: Scenario[] = [
       await client.listTools();
       const first = await client.callTool({
         name: "echo",
-        arguments: { msg: "one", context: "agent supplied 1" },
+        arguments: {
+          msg: "one",
+          context: "agent supplied 1",
+          session_id: "start",
+        },
       });
       const block = mintBackOf(first)!;
-      expect(block).toContain(MINT_BACK_HEADER_SESSION);
+      expect(block).toContain(MINT_BACK_HEADER_ISSUED);
       expect(block).not.toContain("agent_id");
       const sessionId = handleFrom(block, "session_id");
 
@@ -433,9 +445,10 @@ const scenarios: Scenario[] = [
     ...scenarioConfig("task-supplied-continuity"),
     script: async ({ client, capture }) => {
       await client.listTools();
+      // First call of the task sends the start sentinel; the server mints.
       const first = await client.callTool({
         name: "echo",
-        arguments: { msg: "one", context: "continuity 1" },
+        arguments: { msg: "one", context: "continuity 1", session_id: "start" },
       });
       const sessionId = handleFrom(mintBackOf(first)!, "session_id");
       expect(sessionId).toMatch(/^ses_/);
@@ -463,7 +476,7 @@ const scenarios: Scenario[] = [
     },
   },
 
-  // ── 14 ── structured mirror: text mint-back + _mcp_instructions, schema-valid
+  // ── 14 ── structured mirror: text mint-back + mcp_session, schema-valid
   {
     ...scenarioConfig("mint-back-structured-mirror"),
     script: async ({ client, capture }) => {
@@ -471,26 +484,32 @@ const scenarios: Scenario[] = [
       // The injected outputSchema declares the mirror field the client will
       // validate against.
       const listed = findTool(tools, "structured")!;
-      expect(listed.outputSchema.properties._mcp_instructions).toBeDefined();
+      expect(listed.outputSchema.properties.mcp_session).toBeDefined();
 
       // listTools above cached the outputSchema client-side, so this result
       // was ajv-validated against the injected declaration on the way in —
       // "passes declared outputSchema" is proven by the call not throwing.
       const result = await client.callTool({
         name: "structured",
-        arguments: { msg: "mirrored", context: "structured mirror" },
+        arguments: {
+          msg: "mirrored",
+          context: "structured mirror",
+          session_id: "start",
+        },
       });
       const block = mintBackOf(result)!;
       const sessionId = handleFrom(block, "session_id");
-      const mirror = result.structuredContent._mcp_instructions;
+      const mirror = result.structuredContent.mcp_session;
       expect(mirror.session_id).toBe(sessionId);
-      expect(mirror.instructions).toContain("session_id issued");
+      expect(mirror.status).toBe("issued");
       expect(result.structuredContent.echoed).toBe("mirrored");
+      // The mirror leads structuredContent so it survives truncation.
+      expect(Object.keys(result.structuredContent)[0]).toBe("mcp_session");
 
       const [event] = await waitForEvents(capture, 1);
       expect(event.sessionId).toBe(sessionId);
       // The mirror is wire-only: the published response never carries it.
-      expect(JSON.stringify(event.response)).not.toContain("_mcp_instructions");
+      expect(JSON.stringify(event.response)).not.toContain("mcp_session");
     },
   },
 
@@ -762,7 +781,11 @@ const scenarios: Scenario[] = [
       await client.listTools();
       const first = await client.callTool({
         name: "echo",
-        arguments: { msg: "one", context: "session continuity 1" },
+        arguments: {
+          msg: "one",
+          context: "session continuity 1",
+          session_id: "start",
+        },
       });
       const sessionId = handleFrom(mintBackOf(first)!, "session_id");
 

--- a/src/tests/e2e-http/v2-matrix.test.ts
+++ b/src/tests/e2e-http/v2-matrix.test.ts
@@ -42,6 +42,7 @@ import {
   AGENTCAT_TAG_AGENT_SOURCE,
   AGENTCAT_TAG_PROTOCOL_VERSION,
   DEFAULT_CONTEXT_PARAMETER_DESCRIPTION,
+  SESSION_ID_PARAM_PATTERN,
 } from "../../modules/constants.js";
 
 const lanes: Lane[] = [
@@ -67,8 +68,16 @@ const scenarios: Scenario[] = [
       const echo = tools.find((t: any) => t.name === "echo")!;
       expect(echo.inputSchema.properties.context).toBeDefined();
       expect(echo.inputSchema.properties.session_id).toBeDefined();
+      // The injected session_id is schema-required and advertises the
+      // start|ses_ value contract as a pattern.
+      expect(echo.inputSchema.required).toContain("session_id");
+      expect(echo.inputSchema.properties.session_id.pattern).toBe(
+        SESSION_ID_PARAM_PATTERN,
+      );
 
-      // Call with context but no session_id → SDK mints and announces the handle.
+      // Omission tolerance: requiredness is enforced by schema-aware clients
+      // only, so a call without session_id still mints and announces the
+      // handle.
       const result = await client.callTool({
         name: "echo",
         arguments: { msg: "hi", context: "e2e smoke intent" },
@@ -185,8 +194,8 @@ const scenarios: Scenario[] = [
         name: "get_more_tools",
         arguments: { context: missing },
       });
-      expect(result.content[0].text).toContain("Unfortunately");
-      expect(result.content[0].text).toContain(
+      expect(result.content[1].text).toContain("Unfortunately");
+      expect(result.content[1].text).toContain(
         "we have shown you the full tool list",
       );
 
@@ -254,31 +263,36 @@ const scenarios: Scenario[] = [
       const echo = tools.find((t: any) => t.name === "echo")!;
       expect(echo.inputSchema.properties).toHaveProperty("agent_id");
       expect(echo.inputSchema.properties).toHaveProperty("session_id");
-      // agent_id is self-chosen and required; session_id stays optional —
-      // omission is the task-minting signal.
+      // Both injected handles are schema-required with soft enforcement: a
+      // call that omits them still succeeds (minted task / unattributed).
       expect(echo.inputSchema.required).toContain("agent_id");
-      expect(echo.inputSchema.required ?? []).not.toContain("session_id");
+      expect(echo.inputSchema.required).toContain("session_id");
 
       // The structured tool carries the declared outputSchema, so the
       // mint-back mirrors into structuredContent (and the v2 client
       // validated the result against the injected outputSchema in transit).
       // agent_id is omitted here — there is no server-side agent minting, so
-      // the block and mirror carry the session_id only.
+      // the block and mirror carry the session_id only. First call sends
+      // start.
       const result = await client.callTool({
         name: "structured",
-        arguments: { msg: "mint", context: "agent minting" },
+        arguments: {
+          msg: "mint",
+          context: "agent minting",
+          session_id: "start",
+        },
       });
       const block = mintBackOf(result)!;
-      expect(block).toContain("[MCP INSTRUCTIONS]: session_id issued");
+      expect(block).toContain("[session_id issued");
       expect(block).not.toContain("agent_id");
       const sessionId = handleFrom(block, "session_id");
       expect(sessionId).toMatch(/^ses_/);
 
       expect(result.structuredContent.echoed).toBe("mint");
-      const mirror = result.structuredContent._mcp_instructions;
+      const mirror = result.structuredContent.mcp_session;
       expect(mirror.session_id).toBe(sessionId);
       expect(mirror.agent_id).toBeUndefined();
-      expect(mirror.instructions).toContain("session_id issued");
+      expect(mirror.status).toBe("issued");
 
       const [event] = await waitForEvents(capture, 1);
       expect(event.sessionId).toBe(sessionId);
@@ -297,10 +311,14 @@ const scenarios: Scenario[] = [
       await client.listTools();
       const first = await client.callTool({
         name: "echo",
-        arguments: { msg: "one", context: "agent supplied — mint first" },
+        arguments: {
+          msg: "one",
+          context: "agent supplied — mint first",
+          session_id: "start",
+        },
       });
       const block = mintBackOf(first)!;
-      expect(block).toContain("[MCP INSTRUCTIONS]: session_id issued");
+      expect(block).toContain("[session_id issued");
       expect(block).not.toContain("agent_id");
       const sessionId = handleFrom(block, "session_id");
 
@@ -443,9 +461,14 @@ const scenarios: Scenario[] = [
     ...scenarioConfig("task-supplied-continuity"),
     script: async ({ client, capture }) => {
       await client.listTools();
+      // First call of the task sends the start sentinel; the server mints.
       const first = await client.callTool({
         name: "echo",
-        arguments: { msg: "one", context: "continuity — mint" },
+        arguments: {
+          msg: "one",
+          context: "continuity — mint",
+          session_id: "start",
+        },
       });
       const sessionId = handleFrom(mintBackOf(first)!, "session_id");
       expect(sessionId).toMatch(/^ses_/);
@@ -477,31 +500,35 @@ const scenarios: Scenario[] = [
     ...scenarioConfig("mint-back-structured-mirror"),
     script: async ({ client, capture }) => {
       // List first so the typed v2 client validates the call result against
-      // the injected outputSchema (declaring _mcp_instructions) — a result
+      // the injected outputSchema (declaring mcp_session) — a result
       // that failed the declared schema would throw right here.
       await client.listTools();
       const result = await client.callTool({
         name: "structured",
-        arguments: { msg: "mirrored", context: "structured mirror" },
+        arguments: {
+          msg: "mirrored",
+          context: "structured mirror",
+          session_id: "start",
+        },
       });
 
       // Text block + structured mirror, consistent with each other.
       const block = mintBackOf(result)!;
-      expect(block).toContain("[MCP INSTRUCTIONS]: session_id issued");
+      expect(block).toContain("[session_id issued");
       const sessionId = handleFrom(block, "session_id");
       expect(result.structuredContent.echoed).toBe("mirrored");
-      const mirror = result.structuredContent._mcp_instructions;
+      const mirror = result.structuredContent.mcp_session;
       expect(mirror.session_id).toBe(sessionId);
-      expect(mirror.instructions).toContain("session_id issued");
+      expect(mirror.status).toBe("issued");
       // Agent tracking is off → the mirror carries no agent_id.
       expect(mirror.agent_id).toBeUndefined();
+      // The mirror leads structuredContent so it survives truncation.
+      expect(Object.keys(result.structuredContent)[0]).toBe("mcp_session");
 
       const [event] = await waitForEvents(capture, 1);
       expect(event.sessionId).toBe(sessionId);
       // Mint-back is wire-only — never recorded on the event.
-      expect(JSON.stringify(event.response)).not.toContain(
-        "[MCP INSTRUCTIONS]",
-      );
+      expect(JSON.stringify(event.response)).not.toContain("[session_id");
     },
   },
 
@@ -586,7 +613,7 @@ const scenarios: Scenario[] = [
         arguments: { context: "error path intent" },
       });
       // v2 McpServer converts handler throws into isError results; the SDK
-      // still appends the mint-back to the failed result on the wire.
+      // still prepends the mint-back to the failed result on the wire.
       expect(result.isError).toBe(true);
       const block = mintBackOf(result)!;
       expect(handleFrom(block, "session_id")).toMatch(/^ses_/);
@@ -601,9 +628,7 @@ const scenarios: Scenario[] = [
         [AGENTCAT_TAG_SESSION_SOURCE]: "minted",
       });
       // Mint-back stays wire-only even on errors.
-      expect(JSON.stringify(event.response)).not.toContain(
-        "[MCP INSTRUCTIONS]",
-      );
+      expect(JSON.stringify(event.response)).not.toContain("[session_id");
 
       // Follow-up echo on the same lane instance succeeds — the error left
       // no poisoned state behind.
@@ -769,7 +794,11 @@ const scenarios: Scenario[] = [
       await client.listTools();
       const first: any = await client.callTool({
         name: "echo",
-        arguments: { msg: "one", context: "stateful continuity" },
+        arguments: {
+          msg: "one",
+          context: "stateful continuity",
+          session_id: "start",
+        },
       });
       const sessionId = handleFrom(mintBackOf(first)!, "session_id");
       const second: any = await client.callTool({

--- a/src/tests/engine-callwrap.test.ts
+++ b/src/tests/engine-callwrap.test.ts
@@ -166,7 +166,7 @@ describe("installCallWrap (synthetic seam)", () => {
       },
       {},
     );
-    expect(result.content[0].text).toContain("full tool list");
+    expect(result.content[1].text).toContain("full tool list");
     const [event] = capture.getEvents();
     expect(event.resourceName).toBe("get_more_tools");
     expect(event.userIntent).toBe("need csv export");

--- a/src/tests/error-capture.test.ts
+++ b/src/tests/error-capture.test.ts
@@ -325,7 +325,7 @@ describe("Error Capture Integration Tests", () => {
 
       // MCP returns errors as tool results with isError: true
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain("not found");
+      expect(result.content[1].text).toContain("not found");
     } finally {
       await cleanup();
     }

--- a/src/tests/event-tags-properties.test.ts
+++ b/src/tests/event-tags-properties.test.ts
@@ -157,7 +157,7 @@ describe("Event Tags & Properties", () => {
         CallToolResultSchema,
       );
 
-      expect(result.content[0].text).toContain("Added todo");
+      expect(result.content[1].text).toContain("Added todo");
 
       await new Promise((resolve) => setTimeout(resolve, 50));
       const events = eventCapture.getEvents();
@@ -281,7 +281,7 @@ describe("Event Tags & Properties", () => {
         CallToolResultSchema,
       );
 
-      expect(result.content[0].text).toContain("Added todo");
+      expect(result.content[1].text).toContain("Added todo");
     });
 
     it("should handle null return from callback", async () => {

--- a/src/tests/handle-injection.test.ts
+++ b/src/tests/handle-injection.test.ts
@@ -13,10 +13,12 @@ import {
 import { addContextParameterToTools } from "../modules/context-parameters.js";
 import {
   SESSION_ID_PARAM_DESCRIPTION,
+  SESSION_ID_PARAM_PATTERN,
   AGENT_ID_PARAM_DESCRIPTION,
-  AGENT_ID_PARAM_DESCRIPTION_HOOK_MODE,
-  MCP_INSTRUCTIONS_KEY,
-  MCP_INSTRUCTIONS_FIELD_DESCRIPTION,
+  MCP_SESSION_KEY,
+  MCP_SESSION_FIELD_DESCRIPTION,
+  MCP_SESSION_FIELD_DESCRIPTION_HOOK_MODE,
+  MCP_SESSION_STATUS_DESCRIPTION,
 } from "../modules/constants.js";
 
 const makeTool = (name: string, schema?: any) =>
@@ -33,7 +35,7 @@ const customerSchema = () => ({
 });
 
 describe("addHandleParametersToTools", () => {
-  it("injects optional session_id and required agent_id after customer params", () => {
+  it("injects session_id and agent_id after customer params, both required", () => {
     const registry: InjectedParamsRegistry = new Map();
     const [tool] = addHandleParametersToTools(
       [makeTool("add_todo", customerSchema())],
@@ -42,15 +44,26 @@ describe("addHandleParametersToTools", () => {
     );
     const keys = Object.keys(tool.inputSchema.properties);
     expect(keys).toEqual(["text", "session_id", "agent_id"]);
-    // session_id is never required — omission is the minting signal. agent_id is
-    // self-chosen and required when injected.
-    expect(tool.inputSchema.required).toEqual(["text", "agent_id"]);
+    // Requiredness rides injection: both injected params join required, and
+    // the customer's own entries stay first and untouched. Enforcement is
+    // soft — a call that still omits them succeeds (minted / unattributed).
+    expect(tool.inputSchema.required).toEqual([
+      "text",
+      "session_id",
+      "agent_id",
+    ]);
     expect(tool.inputSchema.properties.session_id.description).toBe(
       SESSION_ID_PARAM_DESCRIPTION,
+    );
+    // The injected session_id advertises the start|ses_ value contract as a
+    // JSON Schema pattern; self-chosen agent_id has no pattern in any mode.
+    expect(tool.inputSchema.properties.session_id.pattern).toBe(
+      SESSION_ID_PARAM_PATTERN,
     );
     expect(tool.inputSchema.properties.agent_id.description).toBe(
       AGENT_ID_PARAM_DESCRIPTION,
     );
+    expect(tool.inputSchema.properties.agent_id.pattern).toBeUndefined();
     expect(registry.get("add_todo")).toEqual(
       new Set(["session_id", "agent_id"]),
     );
@@ -67,7 +80,25 @@ describe("addHandleParametersToTools", () => {
       { injectSessionId: true, injectAgentId: true },
       registry,
     );
-    expect(out.inputSchema.required).toEqual(["agent_id"]);
+    expect(out.inputSchema.required).toEqual(["session_id", "agent_id"]);
+  });
+
+  it("does not duplicate session_id in an existing required array", () => {
+    const tool: any = {
+      name: "weird_session",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        required: ["session_id"],
+      },
+    };
+    const registry = new Map();
+    const [out]: any[] = addHandleParametersToTools(
+      [tool],
+      { injectSessionId: true, injectAgentId: false },
+      registry,
+    );
+    expect(out.inputSchema.required).toEqual(["session_id"]);
   });
 
   it("does not duplicate agent_id in an existing required array", () => {
@@ -123,12 +154,18 @@ describe("addHandleParametersToTools", () => {
       "agent_id",
       "context",
     ]);
+    expect(tools[0].inputSchema.required).toEqual([
+      "text",
+      "session_id",
+      "agent_id",
+      "context",
+    ]);
     expect(registry.get("add_todo")).toEqual(
       new Set(["session_id", "agent_id", "context"]),
     );
   });
 
-  it("hook mode: no session_id, agent_id uses the standalone description", () => {
+  it("hook mode: no session_id, agent_id uses the same single description", () => {
     const registry: InjectedParamsRegistry = new Map();
     const [tool] = addHandleParametersToTools(
       [makeTool("add_todo", customerSchema())],
@@ -137,7 +174,7 @@ describe("addHandleParametersToTools", () => {
     );
     expect(tool.inputSchema.properties.session_id).toBeUndefined();
     expect(tool.inputSchema.properties.agent_id.description).toBe(
-      AGENT_ID_PARAM_DESCRIPTION_HOOK_MODE,
+      AGENT_ID_PARAM_DESCRIPTION,
     );
     expect(tool.inputSchema.required).toEqual(["text", "agent_id"]);
     expect(registry.get("add_todo")).toEqual(new Set(["agent_id"]));
@@ -155,9 +192,14 @@ describe("addHandleParametersToTools", () => {
       { injectSessionId: true, injectAgentId: true },
       registry,
     );
+    // The customer's foreign session_id is completely untouched: no pattern,
+    // and never added to required — requiredness rides injection only.
+    // agent_id WAS injected on this tool, so it alone joins required.
     expect(tool.inputSchema.properties.session_id.description).toBe(
       "customer's own",
     );
+    expect(tool.inputSchema.properties.session_id.pattern).toBeUndefined();
+    expect(tool.inputSchema.required).toEqual(["text", "agent_id"]);
     expect(registry.get("deploy")).toEqual(new Set(["agent_id"]));
   });
 
@@ -169,6 +211,8 @@ describe("addHandleParametersToTools", () => {
       registry,
     );
     expect(tool.inputSchema.properties).toBeUndefined();
+    // Composed schemas get no required changes either — fully untouched.
+    expect(tool.inputSchema.required).toBeUndefined();
     expect(registry.has("odd")).toBe(false);
   });
 
@@ -185,6 +229,7 @@ describe("addHandleParametersToTools", () => {
       "session_id",
       "agent_id",
     ]);
+    expect(tools[1].inputSchema.required).toEqual(["session_id", "agent_id"]);
   });
 
   it("does NOT skip get_more_tools (handles are injected; context stays bespoke)", () => {
@@ -206,28 +251,30 @@ describe("addHandleParametersToTools", () => {
       "agent_id",
     ]);
     expect(tools[0].inputSchema.properties.context.description).toBe("bespoke");
+    // Its own required context leads; the injected handles append after it.
+    expect(tools[0].inputSchema.required).toEqual([
+      "context",
+      "session_id",
+      "agent_id",
+    ]);
     expect(registry.get("get_more_tools")).toEqual(
       new Set(["session_id", "agent_id"]),
     );
   });
 
   it("agent_id copy prescribes the self-chosen model|harness|nonce format", () => {
-    for (const copy of [
-      AGENT_ID_PARAM_DESCRIPTION,
-      AGENT_ID_PARAM_DESCRIPTION_HOOK_MODE,
-    ]) {
-      expect(copy).toContain("REQUIRED on every call, including your first");
-      expect(copy).toContain("opus-4.80-1m|claude-code|k3n9x");
-      expect(copy).toContain("generate its own");
-      // The old mint-back protocol must be gone from the copy.
-      expect(copy).not.toContain("the server will issue one");
-      expect(copy).not.toContain("Omit it");
-    }
-    // Only the standard variant ties the agent to the task wording.
-    expect(AGENT_ID_PARAM_DESCRIPTION).toContain("working this task");
-    expect(AGENT_ID_PARAM_DESCRIPTION_HOOK_MODE).not.toContain(
-      "working this task",
+    expect(AGENT_ID_PARAM_DESCRIPTION).toContain(
+      "required on every call including your first",
     );
+    expect(AGENT_ID_PARAM_DESCRIPTION).toContain(
+      "opus-4.80-1m|claude-code|k3n9x",
+    );
+    expect(AGENT_ID_PARAM_DESCRIPTION).toContain("never inherited");
+    // agent_id is self-chosen: the copy never promises server issuance.
+    expect(AGENT_ID_PARAM_DESCRIPTION).not.toContain("the server will issue");
+    // Single constant in both modes: the copy never references the session_id
+    // parameter, so it reads the same with or without one.
+    expect(AGENT_ID_PARAM_DESCRIPTION).not.toContain("session_id");
   });
 });
 
@@ -335,7 +382,7 @@ const objectOutputSchema = () => ({
 });
 
 describe("outputSchema injection", () => {
-  it("injects _mcp_instructions into a plain object outputSchema and registers the tool", () => {
+  it("injects mcp_session into a plain object outputSchema and registers the tool", () => {
     const output: OutputInjectionRegistry = new Set();
     const [tool] = addHandleParametersToTools(
       [structuredTool("get_stats", objectOutputSchema())],
@@ -343,14 +390,20 @@ describe("outputSchema injection", () => {
       new Map(),
       output,
     );
-    const prop = tool.outputSchema.properties[MCP_INSTRUCTIONS_KEY];
+    const prop = tool.outputSchema.properties[MCP_SESSION_KEY];
     expect(prop.type).toBe("object");
-    expect(prop.description).toBe(MCP_INSTRUCTIONS_FIELD_DESCRIPTION);
+    expect(prop.description).toBe(MCP_SESSION_FIELD_DESCRIPTION);
     expect(Object.keys(prop.properties)).toEqual([
       "session_id",
       "agent_id",
-      "instructions",
+      "status",
     ]);
+    // status is the machine-readable session state, pre-announced as an enum.
+    expect(prop.properties.status).toEqual({
+      type: "string",
+      enum: ["issued", "active", "unrecognized"],
+      description: MCP_SESSION_STATUS_DESCRIPTION,
+    });
     // The customer's declared contract is otherwise untouched — including
     // additionalProperties: false, which stays (our property is declared).
     expect(tool.outputSchema.required).toEqual(["count"]);
@@ -359,7 +412,7 @@ describe("outputSchema injection", () => {
     expect(output.has("get_stats")).toBe(true);
   });
 
-  it("sub-properties track modes: hook mode drops session_id, tracking off drops agent_id", () => {
+  it("sub-properties track modes: hook mode drops session_id and status, tracking off drops agent_id", () => {
     const o1: OutputInjectionRegistry = new Set();
     const [hookTool] = addHandleParametersToTools(
       [structuredTool("t", objectOutputSchema())],
@@ -367,11 +420,10 @@ describe("outputSchema injection", () => {
       new Map(),
       o1,
     );
-    expect(
-      Object.keys(
-        hookTool.outputSchema.properties[MCP_INSTRUCTIONS_KEY].properties,
-      ),
-    ).toEqual(["agent_id", "instructions"]);
+    const hookProp = hookTool.outputSchema.properties[MCP_SESSION_KEY];
+    expect(Object.keys(hookProp.properties)).toEqual(["agent_id"]);
+    // Hook mode has no session continuity to describe.
+    expect(hookProp.description).toBe(MCP_SESSION_FIELD_DESCRIPTION_HOOK_MODE);
 
     const o2: OutputInjectionRegistry = new Set();
     const [sessionOnlyTool] = addHandleParametersToTools(
@@ -380,12 +432,13 @@ describe("outputSchema injection", () => {
       new Map(),
       o2,
     );
-    expect(
-      Object.keys(
-        sessionOnlyTool.outputSchema.properties[MCP_INSTRUCTIONS_KEY]
-          .properties,
-      ),
-    ).toEqual(["session_id", "instructions"]);
+    const sessionProp =
+      sessionOnlyTool.outputSchema.properties[MCP_SESSION_KEY];
+    expect(Object.keys(sessionProp.properties)).toEqual([
+      "session_id",
+      "status",
+    ]);
+    expect(sessionProp.description).toBe(MCP_SESSION_FIELD_DESCRIPTION);
   });
 
   it("does not mutate the customer's outputSchema object", () => {
@@ -396,7 +449,7 @@ describe("outputSchema injection", () => {
       new Map(),
       new Set(),
     );
-    expect(schema.properties).not.toHaveProperty(MCP_INSTRUCTIONS_KEY);
+    expect(schema.properties).not.toHaveProperty(MCP_SESSION_KEY);
   });
 
   it("skips complex outputSchema (oneOf/allOf/anyOf) and does not register", () => {
@@ -429,17 +482,15 @@ describe("outputSchema injection", () => {
       output,
     );
     expect(result.outputSchema).toEqual(objectOutputSchema());
-    expect(result.outputSchema.properties).not.toHaveProperty(
-      MCP_INSTRUCTIONS_KEY,
-    );
+    expect(result.outputSchema.properties).not.toHaveProperty(MCP_SESSION_KEY);
     expect(output.size).toBe(0);
   });
 
-  it("collision: a customer-declared _mcp_instructions is never clobbered", () => {
+  it("collision: a customer-declared mcp_session is never clobbered", () => {
     const output: OutputInjectionRegistry = new Set();
     const schema = {
       type: "object",
-      properties: { [MCP_INSTRUCTIONS_KEY]: { type: "string" } },
+      properties: { [MCP_SESSION_KEY]: { type: "string" } },
     };
     const [tool] = addHandleParametersToTools(
       [structuredTool("t", schema)],
@@ -447,7 +498,7 @@ describe("outputSchema injection", () => {
       new Map(),
       output,
     );
-    expect(tool.outputSchema.properties[MCP_INSTRUCTIONS_KEY]).toEqual({
+    expect(tool.outputSchema.properties[MCP_SESSION_KEY]).toEqual({
       type: "string",
     });
     expect(output.size).toBe(0);
@@ -473,9 +524,7 @@ describe("outputSchema injection", () => {
       new Map(),
       output,
     );
-    expect(tool.outputSchema.properties).not.toHaveProperty(
-      MCP_INSTRUCTIONS_KEY,
-    );
+    expect(tool.outputSchema.properties).not.toHaveProperty(MCP_SESSION_KEY);
     expect(output.size).toBe(0);
   });
 

--- a/src/tests/handles-integration.test.ts
+++ b/src/tests/handles-integration.test.ts
@@ -7,6 +7,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { track } from "../index.js";
+import { SESSION_ID_PARAM_PATTERN } from "../modules/constants.js";
 import { EventCapture, setupTestHooks, sid } from "./test-utils.js";
 import {
   setupTestServerAndClient,
@@ -166,13 +167,17 @@ async function setupComposedSchema() {
   };
 }
 
-const mintBackOf = (result: any): string | undefined =>
-  (result.content as any[]).find(
-    (c) => c.type === "text" && c.text.startsWith("[MCP INSTRUCTIONS]"),
-  )?.text;
+// The mint-back block is prepended as the FIRST content element; reading only
+// content[0] makes every consumer of this helper assert the placement too.
+const mintBackOf = (result: any): string | undefined => {
+  const first = (result.content as any[])[0];
+  return first?.type === "text" && first.text.startsWith("[session_id")
+    ? first.text
+    : undefined;
+};
 
 const handleFrom = (text: string, name: string): string =>
-  new RegExp(`${name}=(\\S+)`).exec(text)![1];
+  new RegExp(`${name}: (\\S+)`).exec(text)![1];
 
 describe("low-level server: explicit handles", () => {
   let capture: EventCapture;
@@ -184,7 +189,7 @@ describe("low-level server: explicit handles", () => {
     await capture.stop();
   });
 
-  it("injects optional handles into listed tool schemas", async () => {
+  it("injects required handles into listed tool schemas", async () => {
     const { client, cleanup } = await setupLowLevel();
     const { tools } = await client.listTools();
     const echo = tools.find((t) => t.name === "echo")!;
@@ -194,7 +199,16 @@ describe("low-level server: explicit handles", () => {
       "agent_id",
       "context",
     ]);
-    expect(echo.inputSchema.required).toEqual(["text", "agent_id", "context"]);
+    expect(echo.inputSchema.required).toEqual([
+      "text",
+      "session_id",
+      "agent_id",
+      "context",
+    ]);
+    // The injected session_id advertises the start|ses_ value contract.
+    expect((echo.inputSchema.properties as any).session_id.pattern).toBe(
+      SESSION_ID_PARAM_PATTERN,
+    );
     const gmt = tools.find((t) => t.name === "get_more_tools")!;
     expect(gmt.inputSchema.properties).toHaveProperty("session_id");
     expect(gmt.inputSchema.properties).toHaveProperty("agent_id");
@@ -222,15 +236,15 @@ describe("low-level server: explicit handles", () => {
     await cleanup();
   });
 
-  it("first call mints session_id, appends the mint-back, and tags the task source", async () => {
+  it("first call sends start: mints session_id, prepends the mint-back, tags the source", async () => {
     const { client, cleanup } = await setupLowLevel();
     await client.listTools();
     const result: any = await client.callTool({
       name: "echo",
-      arguments: { text: "hi", context: "testing intent" },
+      arguments: { text: "hi", context: "testing intent", session_id: "start" },
     });
     const block = mintBackOf(result)!;
-    expect(block).toContain("[MCP INSTRUCTIONS]: session_id issued.");
+    expect(block).toContain("[session_id issued");
     expect(block).not.toContain("agent_id");
     const sessionId = handleFrom(block, "session_id");
     expect(sessionId).toMatch(/^ses_/);
@@ -289,7 +303,7 @@ describe("low-level server: explicit handles", () => {
     await cleanup();
   });
 
-  it("appends the mint-back on isError results too", async () => {
+  it("prepends the mint-back on isError results too", async () => {
     const { client, cleanup } = await setupLowLevel();
     await client.listTools();
     const result: any = await client.callTool({
@@ -297,9 +311,7 @@ describe("low-level server: explicit handles", () => {
       arguments: { text: "explode", context: "testing" },
     });
     expect(result.isError).toBe(true);
-    expect(mintBackOf(result)).toContain(
-      "[MCP INSTRUCTIONS]: session_id issued.",
-    );
+    expect(mintBackOf(result)).toContain("[session_id issued");
     expect(mintBackOf(result)).not.toContain("agent_id");
     await cleanup();
   });
@@ -326,7 +338,14 @@ describe("low-level server: explicit handles", () => {
 
   it("a customer's own session_id is never adopted and still reaches the handler", async () => {
     const { client, receivedArgs, cleanup } = await setupOwnSessionId();
-    await client.listTools();
+    const { tools } = await client.listTools();
+    // Foreign param: their schema is completely untouched — no pattern, and
+    // never forced into required.
+    const echo = tools.find((t) => t.name === "echo")!;
+    expect((echo.inputSchema.properties as any).session_id.pattern).toBe(
+      undefined,
+    );
+    expect(echo.inputSchema.required ?? []).not.toContain("session_id");
     await client.callTool({
       name: "echo",
       arguments: { text: "hi", session_id: "CUSTOMER-VALUE-123" },
@@ -335,6 +354,22 @@ describe("low-level server: explicit handles", () => {
     // Their parameter is untouched.
     expect(receivedArgs[0].session_id).toBe("CUSTOMER-VALUE-123");
     // Ours is not polluted by it.
+    const event = capture.findEventByType("mcp:tools/call")!;
+    expect(event.sessionId).toBe("");
+    expect(event.tags.agentcat_session_id_source).toBe("foreign");
+    await cleanup();
+  });
+
+  it("a customer's own session_id param: start is their value too, never a sentinel", async () => {
+    const { client, receivedArgs, cleanup } = await setupOwnSessionId();
+    await client.listTools();
+    await client.callTool({
+      name: "echo",
+      arguments: { text: "hi", session_id: "start" },
+    });
+
+    // Their handler receives the literal value; nothing was minted for it.
+    expect(receivedArgs[0].session_id).toBe("start");
     const event = capture.findEventByType("mcp:tools/call")!;
     expect(event.sessionId).toBe("");
     expect(event.tags.agentcat_session_id_source).toBe("foreign");
@@ -363,7 +398,7 @@ describe("low-level server: explicit handles", () => {
     // Skipping injection must not make the tool sessionless: nobody else
     // declared session_id, so the name is still ours to mint into.
     const block = mintBackOf(result)!;
-    expect(block).toContain("[MCP INSTRUCTIONS]: session_id issued.");
+    expect(block).toContain("[session_id issued");
     const sessionId = handleFrom(block, "session_id");
 
     const event = capture.findEventByType("mcp:tools/call")!;
@@ -396,6 +431,8 @@ describe("low-level server: explicit handles", () => {
     expect(echo.inputSchema.properties).not.toHaveProperty("session_id");
     expect(echo.inputSchema.properties).toHaveProperty("agent_id");
     expect(echo.inputSchema.required).toContain("agent_id");
+    // No session_id injection in hook mode means no requiredness either.
+    expect(echo.inputSchema.required ?? []).not.toContain("session_id");
 
     const result: any = await client.callTool({
       name: "echo",
@@ -449,8 +486,8 @@ describe("low-level server: explicit handles", () => {
       arguments: { text: "hi", context: "testing" },
     });
     const block = mintBackOf(result)!;
-    expect(block).toContain("session_id=");
-    expect(block).not.toContain("agent_id=");
+    expect(block).toContain("session_id: ");
+    expect(block).not.toContain("agent_id");
     const event = capture.findEventByType("mcp:tools/call")!;
     expect(event.tags).not.toHaveProperty("agentcat_agent_id");
     await cleanup();
@@ -465,6 +502,7 @@ describe("low-level server: explicit handles", () => {
     const echo = tools.find((t) => t.name === "echo")!;
     expect(echo.inputSchema.properties).toHaveProperty("session_id");
     expect(echo.inputSchema.properties).toHaveProperty("agent_id");
+    expect(echo.inputSchema.required).toContain("session_id");
     expect(echo.inputSchema.required).toContain("agent_id");
     await cleanup();
   });
@@ -499,7 +537,7 @@ describe("low-level server: explicit handles", () => {
     await cleanup();
   });
 
-  it("declares _mcp_instructions in a listed plain-object outputSchema", async () => {
+  it("declares mcp_session in a listed plain-object outputSchema", async () => {
     const server = new Server(
       { name: "low-level structured server", version: "1.0" },
       { capabilities: { tools: {} } },
@@ -535,12 +573,12 @@ describe("low-level server: explicit handles", () => {
 
     const { tools } = await client.listTools();
     const stats = tools.find((t) => t.name === "stats")!;
-    const prop = (stats.outputSchema!.properties as any)._mcp_instructions;
+    const prop = (stats.outputSchema!.properties as any).mcp_session;
     expect(prop.type).toBe("object");
     expect(Object.keys(prop.properties)).toEqual([
       "session_id",
       "agent_id",
-      "instructions",
+      "status",
     ]);
 
     await clientTransport.close?.();
@@ -559,7 +597,7 @@ describe("high-level server: explicit handles", () => {
     await capture.stop();
   });
 
-  it("mints on first call, appends exactly one mint-back block", async () => {
+  it("mints on first call, prepends exactly one mint-back block", async () => {
     const { server, client, cleanup } = await setupTestServerAndClient();
     track(server, "proj_test");
     await client.listTools();
@@ -568,9 +606,10 @@ describe("high-level server: explicit handles", () => {
       arguments: { text: "buy milk", context: "testing handles" },
     });
     const blocks = (result.content as any[]).filter(
-      (c) => c.type === "text" && c.text.startsWith("[MCP INSTRUCTIONS]"),
+      (c) => c.type === "text" && c.text.startsWith("[session_id"),
     );
     expect(blocks).toHaveLength(1); // outermost wrapper only — never doubled
+    expect((result.content as any[])[0]).toBe(blocks[0]); // and it leads
     const event = capture.findEventByType("mcp:tools/call")!;
     expect(event.sessionId).toBe(handleFrom(blocks[0].text, "session_id"));
     await cleanup();
@@ -612,7 +651,7 @@ describe("high-level server: explicit handles", () => {
       arguments: { text: "buy milk", context: "testing defaults" },
     });
     const block = mintBackOf(result)!;
-    expect(block).toContain("[MCP INSTRUCTIONS]: session_id issued");
+    expect(block).toContain("[session_id issued");
     expect(block).not.toContain("agent_id");
     const event = capture.findEventByType("mcp:tools/call")!;
     expect(event.tags).not.toHaveProperty("agentcat_agent_id");
@@ -628,9 +667,7 @@ describe("high-level server: explicit handles", () => {
       name: "get_more_tools",
       arguments: { context: "need a search tool" },
     });
-    expect(mintBackOf(result)).toContain(
-      "[MCP INSTRUCTIONS]: session_id issued.",
-    );
+    expect(mintBackOf(result)).toContain("[session_id issued");
     expect(mintBackOf(result)).not.toContain("agent_id");
     const event = capture.findEventByType("mcp:tools/call")!;
     expect(event.sessionId).toMatch(/^ses_/);
@@ -694,13 +731,11 @@ describe("published events exclude SDK-authored mint-back text", () => {
       name: "echo",
       arguments: { text: "hi", context: "testing intent" },
     });
-    expect(mintBackOf(result)).toContain(
-      "[MCP INSTRUCTIONS]: session_id issued.",
-    );
+    expect(mintBackOf(result)).toContain("[session_id issued");
     expect(mintBackOf(result)).not.toContain("agent_id");
 
     const event = capture.findEventByType("mcp:tools/call")!;
-    expect(JSON.stringify(event.response)).not.toContain("[MCP INSTRUCTIONS]");
+    expect(JSON.stringify(event.response)).not.toContain("[session_id");
     expect((event.response as any).content).toEqual([
       { type: "text", text: "echo: hi" },
     ]);
@@ -715,16 +750,14 @@ describe("published events exclude SDK-authored mint-back text", () => {
       arguments: { text: "explode", context: "testing" },
     });
     expect(result.isError).toBe(true);
-    expect(mintBackOf(result)).toContain(
-      "[MCP INSTRUCTIONS]: session_id issued.",
-    );
+    expect(mintBackOf(result)).toContain("[session_id issued");
     expect(mintBackOf(result)).not.toContain("agent_id");
 
     const event = capture.findEventByType("mcp:tools/call")!;
     expect(event.isError).toBe(true);
-    expect(JSON.stringify(event.response)).not.toContain("[MCP INSTRUCTIONS]");
+    expect(JSON.stringify(event.response)).not.toContain("[session_id");
     expect(event.error?.message).toContain("boom");
-    expect(event.error?.message).not.toContain("[MCP INSTRUCTIONS]");
+    expect(event.error?.message).not.toContain("[session_id");
     await cleanup();
   });
 
@@ -755,13 +788,11 @@ describe("published events exclude SDK-authored mint-back text", () => {
       name: "add_todo",
       arguments: { text: "buy milk", context: "testing handles" },
     });
-    expect(mintBackOf(result)).toContain(
-      "[MCP INSTRUCTIONS]: session_id issued.",
-    );
+    expect(mintBackOf(result)).toContain("[session_id issued");
     expect(mintBackOf(result)).not.toContain("agent_id");
 
     const event = capture.findEventByType("mcp:tools/call")!;
-    expect(JSON.stringify(event.response)).not.toContain("[MCP INSTRUCTIONS]");
+    expect(JSON.stringify(event.response)).not.toContain("[session_id");
     expect(JSON.stringify(event.response)).toContain("buy milk");
     await cleanup();
   });
@@ -774,13 +805,11 @@ describe("published events exclude SDK-authored mint-back text", () => {
       name: "get_more_tools",
       arguments: { context: "need a search tool" },
     });
-    expect(mintBackOf(result)).toContain(
-      "[MCP INSTRUCTIONS]: session_id issued.",
-    );
+    expect(mintBackOf(result)).toContain("[session_id issued");
     expect(mintBackOf(result)).not.toContain("agent_id");
 
     const event = capture.findEventByType("mcp:tools/call")!;
-    expect(JSON.stringify(event.response)).not.toContain("[MCP INSTRUCTIONS]");
+    expect(JSON.stringify(event.response)).not.toContain("[session_id");
     expect(JSON.stringify(event.response)).toContain(
       "we have shown you the full tool list",
     );

--- a/src/tests/handles.test.ts
+++ b/src/tests/handles.test.ts
@@ -17,7 +17,7 @@ import {
   StructuredMintBack,
   isValidSessionId,
 } from "../modules/handles.js";
-import { MCP_INSTRUCTIONS_KEY } from "../modules/constants.js";
+import { MCP_SESSION_KEY } from "../modules/constants.js";
 import { sid } from "./test-utils.js";
 
 describe("handle primitives", () => {
@@ -95,8 +95,13 @@ describe("handle primitives", () => {
   });
 });
 
-const T = "ses_2xF9kQm3rTvB8nL";
+const T = "ses_2xF9kQm3rTvB8nLpYw7ZcHd4Ke1";
 const A = "opus-4.80-1m|claude-code|k3n9x";
+
+const MINTED_BLOCK = (id: string): string =>
+  "[session_id issued — see this tool's session_id parameter description]\n" +
+  `session_id: ${id}\n` +
+  "This is the first-call issuance described in this tool's session_id parameter description.";
 
 describe("buildMintBackText", () => {
   it("task minted: task-only block, no agent mention even when agent supplied", () => {
@@ -107,11 +112,7 @@ describe("buildMintBackText", () => {
       agentId: A,
       agentSource: "supplied",
     };
-    expect(buildMintBackText(res)).toBe(
-      "[MCP INSTRUCTIONS]: session_id issued.\n" +
-        `  session_id=${T} — required on every subsequent tool call\n` +
-        "Without session_id, this server does not function as intended.",
-    );
+    expect(buildMintBackText(res)).toBe(MINTED_BLOCK(T));
   });
 
   it("task minted without agent tracking: same task-only block", () => {
@@ -120,11 +121,7 @@ describe("buildMintBackText", () => {
       sessionSource: "minted",
       hookMode: false,
     };
-    expect(buildMintBackText(res)).toBe(
-      "[MCP INSTRUCTIONS]: session_id issued.\n" +
-        `  session_id=${T} — required on every subsequent tool call\n` +
-        "Without session_id, this server does not function as intended.",
-    );
+    expect(buildMintBackText(res)).toBe(MINTED_BLOCK(T));
   });
 
   it("task supplied -> null (nothing to announce, agent never mints)", () => {
@@ -151,21 +148,23 @@ describe("buildMintBackText", () => {
 });
 
 describe("appendMintBack", () => {
-  it("appends a text block to array content", () => {
+  it("prepends a text block as the first content element", () => {
     const out = appendMintBack(
       { content: [{ type: "text", text: "hi" }] },
       "BLOCK",
     );
     expect(out.content).toHaveLength(2);
-    expect(out.content[1]).toEqual({ type: "text", text: "BLOCK" });
+    expect(out.content[0]).toEqual({ type: "text", text: "BLOCK" });
+    expect(out.content[1]).toEqual({ type: "text", text: "hi" });
   });
 
-  it("appends on isError results too", () => {
+  it("prepends on isError results too", () => {
     const out = appendMintBack(
       { isError: true, content: [{ type: "text", text: "boom" }] },
       "BLOCK",
     );
     expect(out.content).toHaveLength(2);
+    expect(out.content[0]).toEqual({ type: "text", text: "BLOCK" });
   });
 
   it("leaves non-array content untouched", () => {
@@ -387,6 +386,60 @@ describe("resolveHandles — prompted mode", () => {
     expect(res.sessionSource).toBe("minted");
     expect(res.sessionId).toMatch(/^ses_/);
   });
+
+  it("start sentinel resolves exactly like omission: fresh mint, source minted", async () => {
+    const res = await resolveHandles(
+      {},
+      "proj_1",
+      req({ session_id: "start" }),
+    );
+    expect(res.sessionSource).toBe("minted");
+    expect(res.sessionId).toMatch(/^ses_/);
+    // A fresh, unrelated task per start — never a shared or echoed value.
+    const again = await resolveHandles(
+      {},
+      "proj_1",
+      req({ session_id: "start" }),
+    );
+    expect(again.sessionId).not.toBe(res.sessionId);
+  });
+
+  it.each([["START"], ["Start"], ["sTaRt"], ["  start  "], [" START\t"]])(
+    "start sentinel is case-insensitive and whitespace-tolerant: %j mints",
+    async (value) => {
+      const res = await resolveHandles(
+        {},
+        "proj_1",
+        req({ session_id: value }),
+      );
+      expect(res.sessionSource).toBe("minted");
+      expect(res.sessionId).toMatch(/^ses_/);
+    },
+  );
+
+  it("near-sentinel values stay on the invalid path", async () => {
+    for (const value of ["restart", "start now", "starts", "star t"]) {
+      const res = await resolveHandles(
+        {},
+        "proj_1",
+        req({ session_id: value }),
+      );
+      expect(res.sessionSource).toBe("invalid");
+      expect(res.sessionId).toBe("");
+    }
+  });
+
+  it("foreign param: start is the customer's value, never a sentinel", async () => {
+    const res = await resolveHandles(
+      {},
+      "proj_1",
+      req({ session_id: "start" }),
+      undefined,
+      false,
+    );
+    expect(res.sessionSource).toBe("foreign");
+    expect(res.sessionId).toBe("");
+  });
 });
 
 describe("resolveHandles — hook mode", () => {
@@ -532,7 +585,7 @@ describe("sessionFromHookValue", () => {
 });
 
 describe("buildStructuredMintBack", () => {
-  it("task minted + agent supplied: both ids, task-issued instructions", () => {
+  it("task minted + agent supplied: both ids, status issued", () => {
     const res: HandleResolution = {
       sessionId: T,
       sessionSource: "minted",
@@ -543,11 +596,11 @@ describe("buildStructuredMintBack", () => {
     const mint = buildStructuredMintBack(res)!;
     expect(mint.session_id).toBe(T);
     expect(mint.agent_id).toBe(A);
-    expect(mint.instructions).toContain("session_id issued");
-    expect(mint.instructions).not.toContain("agent_id issued");
+    expect(mint.status).toBe("issued");
+    expect(Object.keys(mint)).toEqual(["session_id", "agent_id", "status"]);
   });
 
-  it("steady state (both supplied): ids plus confirmed copy", () => {
+  it("steady state (both supplied): ids plus status active", () => {
     const res: HandleResolution = {
       sessionId: T,
       sessionSource: "supplied",
@@ -558,11 +611,10 @@ describe("buildStructuredMintBack", () => {
     const mint = buildStructuredMintBack(res)!;
     expect(mint.session_id).toBe(T);
     expect(mint.agent_id).toBe(A);
-    expect(mint.instructions).toContain("session_id and agent_id confirmed");
-    expect(mint.instructions).toContain("these exact values");
+    expect(mint.status).toBe("active");
   });
 
-  it("agent tracking off: task only, singular confirmed copy", () => {
+  it("agent tracking off: task only, status active", () => {
     const res: HandleResolution = {
       sessionId: T,
       sessionSource: "supplied",
@@ -571,11 +623,11 @@ describe("buildStructuredMintBack", () => {
     const mint = buildStructuredMintBack(res)!;
     expect(mint.session_id).toBe(T);
     expect(mint).not.toHaveProperty("agent_id");
-    expect(mint.instructions).toContain("session_id confirmed");
-    expect(mint.instructions).toContain("this exact value");
+    expect(mint.status).toBe("active");
+    expect(Object.keys(mint)).toEqual(["session_id", "status"]);
   });
 
-  it("hook mode never exposes session_id; supplied agent is confirmed", () => {
+  it("hook mode never exposes session_id or status; supplied agent is echoed", () => {
     const res: HandleResolution = {
       sessionId: T,
       sessionSource: "minted",
@@ -585,8 +637,9 @@ describe("buildStructuredMintBack", () => {
     };
     const mint = buildStructuredMintBack(res)!;
     expect(mint).not.toHaveProperty("session_id");
+    expect(mint).not.toHaveProperty("status");
     expect(mint.agent_id).toBe(A);
-    expect(mint.instructions).toContain("agent_id confirmed");
+    expect(Object.keys(mint)).toEqual(["agent_id"]);
   });
 
   it("hook mode with agent tracking off: nothing echoable -> null", () => {
@@ -600,13 +653,15 @@ describe("buildStructuredMintBack", () => {
 });
 
 describe("mirrorStructuredMintBack", () => {
-  const mint: StructuredMintBack = { session_id: T, instructions: "TEXT" };
+  const mint: StructuredMintBack = { session_id: T, status: "issued" };
 
-  it("adds the field to plain-object structuredContent without mutating", () => {
+  it("adds the field as the FIRST key of structuredContent without mutating", () => {
     const original = { content: [], structuredContent: { a: 1 } };
     const out = mirrorStructuredMintBack(original, mint);
-    expect(out.structuredContent[MCP_INSTRUCTIONS_KEY]).toEqual(mint);
+    expect(out.structuredContent[MCP_SESSION_KEY]).toEqual(mint);
     expect(out.structuredContent.a).toBe(1);
+    // The mirror leads so it survives client-side truncation of long results.
+    expect(Object.keys(out.structuredContent)).toEqual([MCP_SESSION_KEY, "a"]);
     // non-mutation of the customer's objects
     expect(original.structuredContent).toEqual({ a: 1 });
     expect(out).not.toBe(original);
@@ -624,7 +679,7 @@ describe("mirrorStructuredMintBack", () => {
 
   it("never clobbers an existing key (customer data wins)", () => {
     const r = {
-      structuredContent: { [MCP_INSTRUCTIONS_KEY]: "customer-owned" },
+      structuredContent: { [MCP_SESSION_KEY]: "customer-owned" },
     };
     expect(mirrorStructuredMintBack(r, mint)).toBe(r);
   });
@@ -632,7 +687,11 @@ describe("mirrorStructuredMintBack", () => {
   it("applies to isError results that carry structuredContent", () => {
     const r = { isError: true, structuredContent: { msg: "boom" } };
     const out = mirrorStructuredMintBack(r, mint);
-    expect(out.structuredContent[MCP_INSTRUCTIONS_KEY]).toEqual(mint);
+    expect(out.structuredContent[MCP_SESSION_KEY]).toEqual(mint);
+    expect(Object.keys(out.structuredContent)).toEqual([
+      MCP_SESSION_KEY,
+      "msg",
+    ]);
   });
 });
 
@@ -675,8 +734,10 @@ describe("invalid and foreign mint-back", () => {
 
   it("invalid: corrects the agent without issuing a replacement", () => {
     const text = buildMintBackText(invalidRes)!;
-    expect(text).toContain("[MCP INSTRUCTIONS]: session_id not recognized.");
-    expect(text).toContain("Re-send the exact session_id");
+    expect(text).toBe(
+      "[session_id unrecognized — see this tool's session_id parameter description]\n" +
+        "The value sent was not issued by this server. Re-send the session_id issued earlier for this task; if none was issued yet, send start and one will be issued.",
+    );
     // No value handed out: nothing that looks like an ID appears.
     expect(text).not.toMatch(/ses_[0-9A-Za-z]{27}/);
   });
@@ -685,17 +746,30 @@ describe("invalid and foreign mint-back", () => {
     // Without this, an agent that hallucinated a session_id on its first call
     // — or a client that auto-filled a param named session_id — is deadlocked:
     // it is told to re-send a value it never received, and this branch never
-    // mints. Omitting the parameter is the only way back to a real session.
+    // mints. Sending start is the way back to a real session.
     const text = buildMintBackText(invalidRes)!;
     expect(text).toContain(
-      "If this server has not issued you a session_id yet, omit the parameter and one will be issued.",
+      "if none was issued yet, send start and one will be issued.",
     );
   });
 
-  it("invalid: structured mirror carries instructions but no session_id", () => {
+  it("invalid: structured mirror carries status unrecognized but no session_id", () => {
     const mint = buildStructuredMintBack(invalidRes)!;
-    expect(mint.instructions).toContain("not recognized");
+    expect(mint.status).toBe("unrecognized");
     expect(mint.session_id).toBeUndefined();
+    expect(Object.keys(mint)).toEqual(["status"]);
+  });
+
+  it("invalid + agent supplied: agent_id rides along with the unrecognized status", () => {
+    const mint = buildStructuredMintBack({
+      ...invalidRes,
+      agentId: "opus|cc|k3n9x",
+      agentSource: "supplied" as const,
+    })!;
+    expect(mint.status).toBe("unrecognized");
+    expect(mint.session_id).toBeUndefined();
+    expect(mint.agent_id).toBe("opus|cc|k3n9x");
+    expect(Object.keys(mint)).toEqual(["agent_id", "status"]);
   });
 
   it("foreign: says nothing when agent_id is not in play either", () => {
@@ -703,17 +777,18 @@ describe("invalid and foreign mint-back", () => {
     expect(buildStructuredMintBack(foreignRes)).toBeNull();
   });
 
-  it("foreign: never confirms the session_id, which is the customer's", () => {
+  it("foreign: never echoes session state, which is the customer's", () => {
     const mint = buildStructuredMintBack({
       ...foreignRes,
       agentId: "opus|cc|k3n9x",
       agentSource: "supplied" as const,
     });
     expect(mint!.session_id).toBeUndefined();
-    expect(mint!.instructions).not.toContain(SESSION_ID_PARAM);
+    expect(mint).not.toHaveProperty(SESSION_ID_PARAM);
+    expect(mint).not.toHaveProperty("status");
   });
 
-  it("foreign: still confirms agent_id, which AgentCat did inject", () => {
+  it("foreign: still echoes agent_id, which AgentCat did inject", () => {
     // A session_id collision skips only session_id injection; agent_id is a
     // separate branch and still ends up in the tool's schema. Suppressing the
     // whole mirror would drop a handle that is ours purely because a
@@ -723,7 +798,7 @@ describe("invalid and foreign mint-back", () => {
       agentId: "opus|cc|k3n9x",
       agentSource: "supplied" as const,
     });
-    expect(mint!.agent_id).toBe("opus|cc|k3n9x");
-    expect(mint!.instructions).toContain(AGENT_ID_PARAM);
+    expect(mint![AGENT_ID_PARAM]).toBe("opus|cc|k3n9x");
+    expect(Object.keys(mint!)).toEqual(["agent_id"]);
   });
 });

--- a/src/tests/identify.test.ts
+++ b/src/tests/identify.test.ts
@@ -73,7 +73,7 @@ describe("Identify Feature", () => {
         CallToolResultSchema,
       );
 
-      expect(result.content[0].text).toContain("Added todo");
+      expect(result.content[1].text).toContain("Added todo");
       expect(identifyCalled).toBe(true);
 
       // Wait for events to be processed
@@ -261,7 +261,7 @@ describe("Identify Feature", () => {
         CallToolResultSchema,
       );
 
-      expect(result.content[0].text).toContain(
+      expect(result.content[1].text).toContain(
         "Processed message: Testing post-track identification",
       );
       expect(identifyCalled).toBe(true);
@@ -417,7 +417,7 @@ describe("Identify Feature", () => {
         CallToolResultSchema,
       );
 
-      expect(result.content[0].text).toContain("Added todo");
+      expect(result.content[1].text).toContain("Added todo");
 
       // Wait for events
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -656,7 +656,7 @@ describe("Identify Feature", () => {
         CallToolResultSchema,
       );
 
-      expect(result.content[0].text).toContain("Added todo");
+      expect(result.content[1].text).toContain("Added todo");
       // The identify hook is deferred: the call returns while the 100ms
       // lookup is still in flight — hooks never hold up the tool call.
       expect(asyncOperationCompleted).toBe(false);
@@ -713,7 +713,7 @@ describe("Identify Feature", () => {
         CallToolResultSchema,
       );
 
-      expect(result.content[0].text).toContain("Added todo");
+      expect(result.content[1].text).toContain("Added todo");
 
       // Wait for events
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -767,7 +767,7 @@ describe("Identify Feature", () => {
         CallToolResultSchema,
       );
 
-      expect(result.content[0].text).toContain("Added todo");
+      expect(result.content[1].text).toContain("Added todo");
 
       // Wait for events
       await new Promise((resolve) => setTimeout(resolve, 50));

--- a/src/tests/posthog-exporter.test.ts
+++ b/src/tests/posthog-exporter.test.ts
@@ -30,7 +30,7 @@ describe("PostHogExporter", () => {
   function makeEvent(overrides: Partial<Event> = {}): Event {
     return {
       id: "evt_test123",
-      sessionId: "ses_session456",
+      sessionId: "ses_session45600000000000000000",
       projectId: "proj_1",
       eventType: PublishEventRequestEventTypeEnum.mcpToolsCall,
       timestamp: new Date("2025-01-15T10:00:00Z"),
@@ -67,7 +67,7 @@ describe("PostHogExporter", () => {
     const event = body.batch[0];
     expect(event.event).toBe("mcp_tool_call");
     expect(event.type).toBe("capture");
-    expect(event.distinct_id).toBe("ses_session456");
+    expect(event.distinct_id).toBe("ses_session45600000000000000000");
     expect(event.timestamp).toBe("2025-01-15T10:00:00.000Z");
 
     // Verify properties
@@ -130,7 +130,7 @@ describe("PostHogExporter", () => {
     await exporter.export(makeEvent({ identifyActorGivenId: undefined }));
 
     const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
-    expect(body.batch[0].distinct_id).toBe("ses_session456");
+    expect(body.batch[0].distinct_id).toBe("ses_session45600000000000000000");
   });
 
   it("should omit $session_id entirely for sessionless events (empty sessionId)", async () => {
@@ -192,7 +192,7 @@ describe("PostHogExporter", () => {
     // Second event: $exception
     const exceptionEvent = body.batch[1];
     expect(exceptionEvent.event).toBe("$exception");
-    expect(exceptionEvent.distinct_id).toBe("ses_session456");
+    expect(exceptionEvent.distinct_id).toBe("ses_session45600000000000000000");
     expect(exceptionEvent.properties.$exception_message).toBe(
       "Connection timeout",
     );
@@ -473,11 +473,13 @@ describe("PostHogExporter", () => {
     const span = body.batch[1];
     expect(span.event).toBe("$ai_span");
     expect(span.type).toBe("capture");
-    expect(span.distinct_id).toBe("ses_session456");
+    expect(span.distinct_id).toBe("ses_session45600000000000000000");
     expect(span.timestamp).toBe("2025-01-15T10:00:00.000Z");
 
     // Core $ai_* properties — full property schema verification
-    expect(span.properties.$ai_session_id).toBe("agentcat_ses_session456");
+    expect(span.properties.$ai_session_id).toBe(
+      "agentcat_ses_session45600000000000000000",
+    );
     expect(span.properties.$ai_trace_id).toBeDefined();
     expect(span.properties.$ai_span_id).toBeDefined();
     expect(span.properties.$ai_trace_id).not.toBe(span.properties.$ai_span_id); // trace from session, span from event

--- a/src/tests/publishCustomEvent.test.ts
+++ b/src/tests/publishCustomEvent.test.ts
@@ -35,7 +35,7 @@ describe("publishCustomEvent", () => {
     // Mock KSUID
     mockKSUID = {
       random: vi.fn().mockResolvedValue("evt_test123"),
-      randomSync: vi.fn().mockReturnValue("ses_test123"),
+      randomSync: vi.fn().mockReturnValue("ses_test12300000000000000000000"),
     };
     (KSUID.withPrefix as any) = vi.fn().mockReturnValue(mockKSUID);
 
@@ -69,14 +69,14 @@ describe("publishCustomEvent", () => {
       // Mock server tracking data
       (getServerTrackingData as any).mockReturnValue({
         projectId: "proj_tracked",
-        sessionId: "ses_tracked123",
+        sessionId: "ses_tracked12300000000000000000",
         options: {},
       });
     });
 
     it("should publish custom event with tracked server", async () => {
       const eventData: CustomEventData = {
-        sessionId: "ses_srv",
+        sessionId: "ses_srv000000000000000000000000",
         resourceName: "custom-action",
         parameters: { action: "test" },
         message: "Testing custom event",
@@ -88,7 +88,7 @@ describe("publishCustomEvent", () => {
       expect(publishEventToQueue).toHaveBeenCalledWith(
         mockServer,
         expect.objectContaining({
-          sessionId: "ses_srv",
+          sessionId: "ses_srv000000000000000000000000",
           projectId,
           eventType: "agentcat:custom",
           resourceName: "custom-action",
@@ -103,12 +103,14 @@ describe("publishCustomEvent", () => {
 
     it("should use eventData.sessionId as the session id, not any ambient server session", async () => {
       await publishCustomEvent(mockServer, projectId, {
-        sessionId: "ses_srv",
+        sessionId: "ses_srv000000000000000000000000",
       });
 
       expect(publishEventToQueue).toHaveBeenCalledWith(
         mockServer,
-        expect.objectContaining({ sessionId: "ses_srv" }),
+        expect.objectContaining({
+          sessionId: "ses_srv000000000000000000000000",
+        }),
       );
     });
 
@@ -191,12 +193,12 @@ describe("publishCustomEvent", () => {
 
     it("should let eventData.sessionId take precedence over the string", async () => {
       await publishCustomEvent("ignored-string", "proj", {
-        sessionId: "ses_wins",
+        sessionId: "ses_wins00000000000000000000000",
       });
 
       expect(mockEventQueue.add).toHaveBeenCalledWith(
         expect.objectContaining({
-          sessionId: "ses_wins",
+          sessionId: "ses_wins00000000000000000000000",
           projectId: "proj",
         }),
       );

--- a/src/tests/redaction.test.ts
+++ b/src/tests/redaction.test.ts
@@ -27,7 +27,7 @@ describe("redactEvent", () => {
 
   it("should redact basic string fields", async () => {
     const event: UnredactedEvent = {
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       userIntent: "sensitive user intent",
       timestamp: new Date("2024-01-01"),
     };
@@ -72,7 +72,7 @@ describe("redactEvent", () => {
 
   it("should not redact protected fields", async () => {
     const event: UnredactedEvent = {
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       id: "evt_456",
       projectId: "proj_789",
       server: "my-server",
@@ -90,7 +90,7 @@ describe("redactEvent", () => {
     const redacted = await redactEvent(event, mockRedactFn);
 
     // All protected fields should remain unchanged
-    expect(redacted.sessionId).toBe("ses_123");
+    expect(redacted.sessionId).toBe("ses_123000000000000000000000000");
     expect(redacted.id).toBe("evt_456");
     expect(redacted.projectId).toBe("proj_789");
     expect(redacted.server).toBe("my-server");
@@ -110,7 +110,7 @@ describe("redactEvent", () => {
 
   it("should redact nested string fields", async () => {
     const event: UnredactedEvent = {
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       parameters: {
         query: "sensitive query",
         options: {
@@ -137,7 +137,7 @@ describe("redactEvent", () => {
 
   it("should handle arrays of strings", async () => {
     const event: UnredactedEvent = {
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       parameters: {
         tags: ["sensitive1", "sensitive2", "sensitive3"],
         numbers: [1, 2, 3],
@@ -156,7 +156,7 @@ describe("redactEvent", () => {
 
   it("should handle mixed nested structures", async () => {
     const event: UnredactedEvent = {
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       parameters: {
         users: [
           { name: "John", age: 30, email: "john@example.com" },
@@ -177,7 +177,7 @@ describe("redactEvent", () => {
 
   it("should preserve null and undefined values", async () => {
     const event: UnredactedEvent = {
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       parameters: {
         nullValue: null,
         undefinedValue: undefined,
@@ -195,7 +195,7 @@ describe("redactEvent", () => {
   it("should preserve Date objects", async () => {
     const testDate = new Date("2024-01-01T12:00:00Z");
     const event: UnredactedEvent = {
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       timestamp: testDate,
       parameters: {
         createdAt: new Date("2024-01-02T12:00:00Z"),
@@ -213,7 +213,7 @@ describe("redactEvent", () => {
 
   it("should skip functions in objects", async () => {
     const event: UnredactedEvent = {
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       parameters: {
         callback: () => console.log("test"),
         data: "sensitive data",
@@ -228,7 +228,7 @@ describe("redactEvent", () => {
 
   it("should handle complex identifyData object without redacting it", async () => {
     const event: UnredactedEvent = {
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       identifyData: {
         email: "user@example.com",
         preferences: {
@@ -260,7 +260,7 @@ describe("redactEvent", () => {
 
   it("should handle error objects", async () => {
     const event: UnredactedEvent = {
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       isError: true,
       error: {
         message: "Sensitive error message",
@@ -280,7 +280,7 @@ describe("redactEvent", () => {
 
   it("should handle deeply nested protected fields correctly", async () => {
     const event: UnredactedEvent = {
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       parameters: {
         nested: {
           deeply: {
@@ -293,7 +293,7 @@ describe("redactEvent", () => {
 
     const redacted = await redactEvent(event, mockRedactFn);
 
-    expect(redacted.sessionId).toBe("ses_123"); // Top-level protected
+    expect(redacted.sessionId).toBe("ses_123000000000000000000000000"); // Top-level protected
     expect(redacted.parameters.nested.deeply.sessionId).toBe("[REDACTED-23]"); // Nested not protected
     expect(redacted.parameters.nested.deeply.data).toBe("[REDACTED-14]");
   });
@@ -304,7 +304,7 @@ describe("redactEvent", () => {
     });
 
     const event: UnredactedEvent = {
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       userIntent: "sensitive data",
     };
 
@@ -315,7 +315,7 @@ describe("redactEvent", () => {
 
   it("should not redact nested fields within any protected field", async () => {
     const event: UnredactedEvent = {
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       // Test nested data in identifyData
       identifyData: {
         nested: {
@@ -362,7 +362,7 @@ describe("redactEvent", () => {
 
   it("should create a new object without modifying the original", async () => {
     const event: UnredactedEvent = {
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       userIntent: "sensitive data",
       parameters: {
         query: "sensitive query",
@@ -384,7 +384,7 @@ describe("redactEvent", () => {
     const event: UnredactedEvent = {
       id: "evt_123",
       projectId: "proj_123",
-      sessionId: "ses_123",
+      sessionId: "ses_123000000000000000000000000",
       actorId: "actor_123",
       eventId: "custom_evt_123",
       eventType: "mcp:tools/call",
@@ -407,7 +407,7 @@ describe("redactEvent", () => {
     // Protected fields
     expect(redacted.id).toBe("evt_123");
     expect(redacted.projectId).toBe("proj_123");
-    expect(redacted.sessionId).toBe("ses_123");
+    expect(redacted.sessionId).toBe("ses_123000000000000000000000000");
     expect(redacted.actorId).toBe("actor_123");
     expect(redacted.eventType).toBe("mcp:tools/call");
     expect(redacted.resourceName).toBe("resource_123");
@@ -434,7 +434,7 @@ describe("redactEvent", () => {
 describe("applyEventRedaction", () => {
   const baseEvent = (): UnredactedEvent => ({
     id: "evt_original",
-    sessionId: "ses_123",
+    sessionId: "ses_123000000000000000000000000",
     projectId: "proj_789",
     eventType: "mcp:tools/call",
     timestamp: new Date("2024-01-01"),
@@ -514,7 +514,7 @@ describe("applyEventRedaction", () => {
     const hook: RedactEventFunction = (event) => {
       const copy = { ...event };
       copy.id = "evt_forged";
-      copy.sessionId = "ses_forged";
+      copy.sessionId = "ses_forged000000000000000000000";
       copy.projectId = "proj_forged";
       copy.eventType = "forged:event";
       delete copy.timestamp;
@@ -525,7 +525,7 @@ describe("applyEventRedaction", () => {
     await applyEventRedaction(event, hook);
 
     expect(event.id).toBe("evt_original");
-    expect(event.sessionId).toBe("ses_123");
+    expect(event.sessionId).toBe("ses_123000000000000000000000000");
     expect(event.projectId).toBe("proj_789");
     expect(event.eventType).toBe("mcp:tools/call");
     expect(event.timestamp).toEqual(new Date("2024-01-01"));

--- a/src/tests/report-missing.test.ts
+++ b/src/tests/report-missing.test.ts
@@ -163,7 +163,7 @@ describe("Report Missing Tool", () => {
       );
 
       // Verify response
-      expect(result.content[0].text).toContain("Unfortunately");
+      expect(result.content[1].text).toContain("Unfortunately");
 
       // Wait for events
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -212,7 +212,7 @@ describe("Report Missing Tool", () => {
       );
 
       // Verify response acknowledges the feedback
-      expect(result.content[0].text).toContain("Unfortunately");
+      expect(result.content[1].text).toContain("Unfortunately");
 
       // Wait for events
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -258,7 +258,7 @@ describe("Report Missing Tool", () => {
       );
 
       // The function handles undefined gracefully
-      expect(result.content[0].text).toContain("Unfortunately");
+      expect(result.content[1].text).toContain("Unfortunately");
 
       await eventCapture.stop();
     });

--- a/src/tests/structured-mintback.test.ts
+++ b/src/tests/structured-mintback.test.ts
@@ -110,32 +110,34 @@ describe("structured mint-back: high-level (V2) path", () => {
       arguments: { context: "checking stats" },
     });
     const sc = result.structuredContent;
-    const mint = sc._mcp_instructions;
+    const mint = sc.mcp_session;
     expect(mint.session_id).toMatch(/^ses_/);
     expect(mint).not.toHaveProperty("agent_id");
-    expect(mint.instructions).toContain("session_id issued");
+    expect(mint.status).toBe("issued");
     expect(sc.count).toBe(0); // customer payload intact
+    // The mirror leads so it survives client-side truncation of long results.
+    expect(Object.keys(sc)[0]).toBe("mcp_session");
     await cleanup();
   });
 
-  it("tools/list declares _mcp_instructions on get_stats; schema-less tools untouched", async () => {
+  it("tools/list declares mcp_session on get_stats; schema-less tools untouched", async () => {
     const { server, client, cleanup } = await setupTestServerAndClient();
     track(server, "proj_test", { enableAgentTracking: true });
     const { tools } = await client.listTools();
     const stats = tools.find((t) => t.name === "get_stats")!;
-    const prop = (stats.outputSchema as any).properties._mcp_instructions;
+    const prop = (stats.outputSchema as any).properties.mcp_session;
     expect(prop.type).toBe("object");
     expect(Object.keys(prop.properties)).toEqual([
       "session_id",
       "agent_id",
-      "instructions",
+      "status",
     ]);
     const addTodo = tools.find((t) => t.name === "add_todo")!;
     expect(addTodo.outputSchema).toBeUndefined();
     await cleanup();
   });
 
-  it("steady state: supplied handles are re-confirmed on every response; footer stays mint-only", async () => {
+  it("steady state: supplied handles are re-echoed on every response; text block stays mint-only", async () => {
     const { server, client, cleanup } = await setupTestServerAndClient();
     track(server, "proj_test", { enableAgentTracking: true });
     await client.listTools();
@@ -147,19 +149,19 @@ describe("structured mint-back: high-level (V2) path", () => {
         agent_id: "opus-4.80-1m|claude-code|k3n9x",
       },
     });
-    const mint = result.structuredContent._mcp_instructions;
+    const mint = result.structuredContent.mcp_session;
     expect(mint.session_id).toBe(sid("fixed"));
     expect(mint.agent_id).toBe("opus-4.80-1m|claude-code|k3n9x");
-    expect(mint.instructions).toContain("confirmed");
-    // content footer is a mint-time announcement only — none in steady state
-    const footer = (result.content as any[]).find(
-      (c: any) => c.type === "text" && c.text.startsWith("[MCP INSTRUCTIONS]"),
+    expect(mint.status).toBe("active");
+    // the text block is a mint-time announcement only — none in steady state
+    const block = (result.content as any[]).find(
+      (c: any) => c.type === "text" && c.text.startsWith("[session_id"),
     );
-    expect(footer).toBeUndefined();
+    expect(block).toBeUndefined();
     await cleanup();
   });
 
-  it("wire-only: published event.response never contains _mcp_instructions", async () => {
+  it("wire-only: published event.response never contains mcp_session", async () => {
     const { server, client, cleanup } = await setupTestServerAndClient();
     track(server, "proj_test", { enableAgentTracking: true });
     await client.listTools();
@@ -169,13 +171,13 @@ describe("structured mint-back: high-level (V2) path", () => {
     });
     const event = capture.findEventByType("mcp:tools/call")!;
     const published = JSON.stringify(event.response);
-    expect(published).not.toContain("_mcp_instructions");
-    expect(published).not.toContain("[MCP INSTRUCTIONS]");
+    expect(published).not.toContain("mcp_session");
+    expect(published).not.toContain("[session_id");
     expect((event.response as any).structuredContent).toEqual({ count: 0 });
     await cleanup();
   });
 
-  it("content-only tools are unaffected: footer present, no structuredContent conjured", async () => {
+  it("content-only tools are unaffected: block leads content, no structuredContent conjured", async () => {
     const { server, client, cleanup } = await setupTestServerAndClient();
     track(server, "proj_test", { enableAgentTracking: true });
     await client.listTools();
@@ -184,10 +186,10 @@ describe("structured mint-back: high-level (V2) path", () => {
       arguments: { text: "buy milk", context: "testing" },
     });
     expect(result.structuredContent).toBeUndefined();
-    const footer = (result.content as any[]).find(
-      (c: any) => c.type === "text" && c.text.startsWith("[MCP INSTRUCTIONS]"),
-    );
-    expect(footer).toBeDefined();
+    // Prepended as the FIRST content element so it survives truncation.
+    const first = (result.content as any[])[0];
+    expect(first.type).toBe("text");
+    expect(first.text).toMatch(/^\[session_id issued/);
     await cleanup();
   });
 });
@@ -206,34 +208,32 @@ describe("structured mint-back: low-level (V1) path", () => {
     const { client, cleanup } = await setupLowLevelStructured();
     await client.listTools();
     const result: any = await client.callTool({ name: "stats", arguments: {} });
-    const mint = result.structuredContent._mcp_instructions;
+    const mint = result.structuredContent.mcp_session;
     expect(mint.session_id).toMatch(/^ses_/);
     expect(mint).not.toHaveProperty("agent_id");
-    expect(mint.instructions).toContain("session_id issued");
+    expect(mint.status).toBe("issued");
     expect(result.structuredContent.count).toBe(42);
+    expect(Object.keys(result.structuredContent)[0]).toBe("mcp_session");
     const event = capture.findEventByType("mcp:tools/call")!;
-    expect(JSON.stringify(event.response)).not.toContain("_mcp_instructions");
+    expect(JSON.stringify(event.response)).not.toContain("mcp_session");
     await cleanup();
   });
 
-  it("composed outputSchema: schema untouched, no mirror, footer still delivers", async () => {
+  it("composed outputSchema: schema untouched, no mirror, text block still delivers", async () => {
     const { client, cleanup } = await setupLowLevelStructured();
     const { tools } = await client.listTools();
     const poly = tools.find((t) => t.name === "poly")!;
-    expect(JSON.stringify(poly.outputSchema)).not.toContain(
-      "_mcp_instructions",
-    );
+    expect(JSON.stringify(poly.outputSchema)).not.toContain("mcp_session");
     const result: any = await client.callTool({ name: "poly", arguments: {} });
-    expect(result.structuredContent._mcp_instructions).toBeUndefined();
+    expect(result.structuredContent.mcp_session).toBeUndefined();
     expect(result.structuredContent.a).toBe("x");
-    const footer = (result.content as any[]).find(
-      (c: any) => c.type === "text" && c.text.startsWith("[MCP INSTRUCTIONS]"),
-    );
-    expect(footer).toBeDefined();
+    const first = (result.content as any[])[0];
+    expect(first.type).toBe("text");
+    expect(first.text).toMatch(/^\[session_id issued/);
     await cleanup();
   });
 
-  it("hook mode: mirrored payload carries agent_id but never session_id", async () => {
+  it("hook mode: mirrored payload carries agent_id but never session_id or status", async () => {
     const { client, cleanup } = await setupLowLevelStructured({
       resolveSessionId: () => "corr-1",
     });
@@ -242,10 +242,10 @@ describe("structured mint-back: low-level (V1) path", () => {
       name: "stats",
       arguments: { agent_id: "opus-4.80-1m|claude-code|k3n9x" },
     });
-    const mint = result.structuredContent._mcp_instructions;
+    const mint = result.structuredContent.mcp_session;
     expect(mint).not.toHaveProperty("session_id");
+    expect(mint).not.toHaveProperty("status");
     expect(mint.agent_id).toBe("opus-4.80-1m|claude-code|k3n9x");
-    expect(mint.instructions).toContain("agent_id confirmed");
     await cleanup();
   });
 
@@ -257,9 +257,7 @@ describe("structured mint-back: low-level (V1) path", () => {
       { method: "tools/call", params: { name: "stats", arguments: {} } },
       {},
     );
-    expect(result.structuredContent._mcp_instructions.session_id).toMatch(
-      /^ses_/,
-    );
+    expect(result.structuredContent.mcp_session.session_id).toMatch(/^ses_/);
     await cleanup();
   });
 });

--- a/src/tests/truncation.test.ts
+++ b/src/tests/truncation.test.ts
@@ -463,7 +463,7 @@ describe("truncateEvent - edge cases", () => {
     const ts = new Date("2025-01-15T12:00:00Z");
     const event = makeEvent({
       id: "evt_abc123",
-      sessionId: "ses_xyz789",
+      sessionId: "ses_xyz789000000000000000000000",
       projectId: "proj_test",
       eventType: "mcp:tools/call",
       timestamp: ts,
@@ -475,7 +475,7 @@ describe("truncateEvent - edge cases", () => {
     });
     const result = truncateEvent(event);
     expect(result.id).toBe("evt_abc123");
-    expect(result.sessionId).toBe("ses_xyz789");
+    expect(result.sessionId).toBe("ses_xyz789000000000000000000000");
     expect(result.projectId).toBe("proj_test");
     expect(result.eventType).toBe("mcp:tools/call");
     expect(result.timestamp).toBe(ts);

--- a/src/tests/v2/agent-tracking.test.ts
+++ b/src/tests/v2/agent-tracking.test.ts
@@ -43,21 +43,20 @@ describe("v2 agent tracking: enableAgentTracking true", () => {
     await capture.stop();
   });
 
-  it("advertises agent_id as required on every tool including get_more_tools", async () => {
+  it("advertises both handles as required on every tool including get_more_tools", async () => {
     const { client } = await setupHighLevel({ enableAgentTracking: true });
     const { tools } = await client.listTools();
     const echo = tools.find((t) => t.name === "echo")!;
     expect((echo.inputSchema as any).properties).toHaveProperty("agent_id");
     expect((echo.inputSchema as any).properties).toHaveProperty("session_id");
-    // agent_id is self-chosen and required; session_id stays optional (omission
-    // is the minting signal).
+    // Both injected handles are schema-required with soft enforcement: a
+    // call that omits them still succeeds (minted task / unattributed event).
     expect((echo.inputSchema as any).required).toContain("agent_id");
-    expect((echo.inputSchema as any).required ?? []).not.toContain(
-      "session_id",
-    );
+    expect((echo.inputSchema as any).required).toContain("session_id");
     const gmt = tools.find((t) => t.name === "get_more_tools")!;
     expect((gmt.inputSchema as any).properties).toHaveProperty("agent_id");
     expect((gmt.inputSchema as any).required).toContain("agent_id");
+    expect((gmt.inputSchema as any).required).toContain("session_id");
     await client.close();
   });
 
@@ -68,10 +67,10 @@ describe("v2 agent tracking: enableAgentTracking true", () => {
       arguments: { msg: "hi", context: "agent omission" },
     });
     const block = mintBackOf(result)!;
-    expect(block).toContain("[MCP INSTRUCTIONS]: session_id issued");
+    expect(block).toContain("[session_id issued");
     expect(block).not.toContain("agent_id");
 
-    const mirror = result.structuredContent._mcp_instructions;
+    const mirror = result.structuredContent.mcp_session;
     expect(mirror.session_id).toBe(handleFrom(block, "session_id"));
     expect(mirror).not.toHaveProperty("agent_id");
 
@@ -93,10 +92,10 @@ describe("v2 agent tracking: enableAgentTracking true", () => {
       },
     });
     expect(mintBackOf(result)).toBeUndefined();
-    const mirror = result.structuredContent._mcp_instructions;
+    const mirror = result.structuredContent.mcp_session;
     expect(mirror.session_id).toBe(sid("fixed"));
     expect(mirror.agent_id).toBe("opus-4.80-1m|claude-code|k3n9x");
-    expect(mirror.instructions).toContain("confirmed");
+    expect(mirror.status).toBe("active");
 
     const [event] = capture.getEvents();
     expect(event.sessionId).toBe(sid("fixed"));
@@ -150,7 +149,7 @@ describe("v2 agent tracking: OFF by default", () => {
       arguments: { msg: "hi", context: "defaults" },
     });
     const block = mintBackOf(result)!;
-    expect(block).toContain("[MCP INSTRUCTIONS]: session_id issued");
+    expect(block).toContain("[session_id issued");
     expect(block).not.toContain("agent_id");
     const [event] = capture.getEvents();
     expect(event.tags).not.toHaveProperty(AGENTCAT_TAG_AGENT_ID);

--- a/src/tests/v2/era-2026.test.ts
+++ b/src/tests/v2/era-2026.test.ts
@@ -95,7 +95,7 @@ describe("2026-07-28 era via createMcpHandler", () => {
       name: "echo",
       arguments: { msg: "solo" },
     })) as any;
-    expect(result.content[0].text).toContain("solo");
+    expect(result.content[1].text).toContain("solo");
     const [event] = capture
       .getEvents()
       .filter((e) => e.resourceName === "echo");

--- a/src/tests/v2/get-more-tools.test.ts
+++ b/src/tests/v2/get-more-tools.test.ts
@@ -48,6 +48,7 @@ describe("v2 get_more_tools on a tracked high-level server", () => {
     expect((gmt.inputSchema as any).required).toContain("context");
     expect((gmt.inputSchema as any).properties).toHaveProperty("session_id");
     expect((gmt.inputSchema as any).properties).toHaveProperty("agent_id");
+    expect((gmt.inputSchema as any).required).toContain("session_id");
     expect((gmt.inputSchema as any).required).toContain("agent_id");
     expect(gmt.annotations).toEqual({
       title: "Get More Tools",
@@ -66,8 +67,8 @@ describe("v2 get_more_tools on a tracked high-level server", () => {
       name: "get_more_tools",
       arguments: { context: missingDescription },
     });
-    expect(result.content[0].text).toContain("Unfortunately");
-    expect(result.content[0].text).toContain(
+    expect(result.content[1].text).toContain("Unfortunately");
+    expect(result.content[1].text).toContain(
       "we have shown you the full tool list",
     );
 
@@ -93,7 +94,7 @@ describe("v2 get_more_tools on a tracked high-level server", () => {
       },
     });
     const block = mintBackOf(result)!;
-    expect(block).toContain("[MCP INSTRUCTIONS]: session_id issued");
+    expect(block).toContain("[session_id issued");
     expect(block).not.toContain("agent_id");
     expect(handleFrom(block, "session_id")).toMatch(/^ses_/);
 
@@ -104,7 +105,7 @@ describe("v2 get_more_tools on a tracked high-level server", () => {
       [AGENTCAT_TAG_AGENT_SOURCE]: "supplied",
     });
     // Mint-back is wire-only — never recorded on the event.
-    expect(JSON.stringify(event.response)).not.toContain("[MCP INSTRUCTIONS]");
+    expect(JSON.stringify(event.response)).not.toContain("[session_id");
     expect(JSON.stringify(event.response)).toContain(
       "we have shown you the full tool list",
     );

--- a/src/tests/v2/harness.ts
+++ b/src/tests/v2/harness.ts
@@ -19,12 +19,18 @@ export async function connectClient(server: {
   return client;
 }
 
-/** Extracts the SDK-authored [MCP INSTRUCTIONS] text block from a result. */
-export const mintBackOf = (result: any): string | undefined =>
-  (result.content as any[]).find(
-    (c) => c.type === "text" && c.text.startsWith("[MCP INSTRUCTIONS]"),
-  )?.text;
+/**
+ * Extracts the SDK-authored [session_id …] text block from a result. The
+ * block is prepended as the FIRST content element; reading only content[0]
+ * makes every consumer of this helper assert the placement too.
+ */
+export const mintBackOf = (result: any): string | undefined => {
+  const first = (result.content as any[])[0];
+  return first?.type === "text" && first.text.startsWith("[session_id")
+    ? first.text
+    : undefined;
+};
 
-/** Reads `name=<value>` out of a mint-back block. */
+/** Reads `name: <value>` out of a mint-back block. */
 export const handleFrom = (text: string, name: string): string =>
-  new RegExp(`${name}=(\\S+)`).exec(text)![1];
+  new RegExp(`${name}: (\\S+)`).exec(text)![1];

--- a/src/tests/v2/hooks.test.ts
+++ b/src/tests/v2/hooks.test.ts
@@ -102,7 +102,7 @@ describe("v2 hooks: identify", () => {
       name: "add_note",
       arguments: { text: "hello", context: "identification test" },
     });
-    expect(result.content[0].text).toContain("Added note");
+    expect(result.content[1].text).toContain("Added note");
     expect(identifyCalled).toBe(true);
 
     // No separate identify event exists — the resolved identity is stamped
@@ -192,7 +192,7 @@ describe("v2 hooks: identify", () => {
       name: "add_note",
       arguments: { text: "anon", context: "null identity test" },
     });
-    expect(result.content[0].text).toContain("Added note");
+    expect(result.content[1].text).toContain("Added note");
 
     const [toolCallEvent] = toolCallEventsOf(capture);
     expect(toolCallEvent).toBeDefined();
@@ -213,7 +213,7 @@ describe("v2 hooks: identify", () => {
       name: "add_note",
       arguments: { text: "err", context: "identify error test" },
     });
-    expect(result.content[0].text).toContain("Added note");
+    expect(result.content[1].text).toContain("Added note");
 
     const [toolCallEvent] = toolCallEventsOf(capture);
     expect(toolCallEvent).toBeDefined();
@@ -233,7 +233,7 @@ describe("v2 hooks: identify", () => {
       name: "add_note",
       arguments: { text: "invalid", context: "invalid identity test" },
     });
-    expect(result.content[0].text).toContain("Added note");
+    expect(result.content[1].text).toContain("Added note");
 
     const [toolCallEvent] = toolCallEventsOf(capture);
     expect(toolCallEvent.identifyActorGivenId).toBeUndefined();
@@ -256,7 +256,7 @@ describe("v2 hooks: identify", () => {
       name: "add_note",
       arguments: { text: "async", context: "async identify test" },
     });
-    expect(result.content[0].text).toContain("Added note");
+    expect(result.content[1].text).toContain("Added note");
     // Deferred hooks: the 100ms lookup never held the call open.
     expect(asyncOperationCompleted).toBe(false);
 
@@ -364,7 +364,7 @@ describe("v2 hooks: eventTags", () => {
       name: "add_note",
       arguments: { text: "throw", context: "tag test" },
     });
-    expect(result.content[0].text).toContain("Added note");
+    expect(result.content[1].text).toContain("Added note");
 
     const [toolCallEvent] = toolCallEventsOf(capture);
     expect(customerTags(toolCallEvent.tags)).toEqual({});
@@ -452,7 +452,7 @@ describe("v2 hooks: eventProperties", () => {
       name: "add_note",
       arguments: { text: "throw", context: "props test" },
     });
-    expect(result.content[0].text).toContain("Added note");
+    expect(result.content[1].text).toContain("Added note");
     await client.close();
   });
 

--- a/src/tests/v2/late-registration.test.ts
+++ b/src/tests/v2/late-registration.test.ts
@@ -166,7 +166,7 @@ describe("v2 late registration: registerTool AFTER track()", () => {
         context: "verifying identify on dynamically added tools",
       },
     });
-    expect(result.content[0].text).toContain("post-track identification");
+    expect(result.content[1].text).toContain("post-track identification");
     expect(identifyCalled).toBe(true);
 
     const [event] = capture.getEvents();

--- a/src/tests/v2/lowlevel-handles.test.ts
+++ b/src/tests/v2/lowlevel-handles.test.ts
@@ -67,7 +67,7 @@ describe("v2 low-level server: explicit handles", () => {
     await capture.stop();
   });
 
-  it("injects optional handles into listed tool schemas in canonical order", async () => {
+  it("injects required handles into listed tool schemas in canonical order", async () => {
     const { client } = await setupLowLevel();
     const { tools } = await client.listTools();
     const echo = tools.find((t) => t.name === "echo")!;
@@ -79,6 +79,7 @@ describe("v2 low-level server: explicit handles", () => {
     ]);
     expect((echo.inputSchema as any).required).toEqual([
       "text",
+      "session_id",
       "agent_id",
       "context",
     ]);
@@ -102,15 +103,15 @@ describe("v2 low-level server: explicit handles", () => {
     await client.close();
   });
 
-  it("first call mints session_id, appends the mint-back, and tags the task source", async () => {
+  it("first call sends start: mints session_id, prepends the mint-back, tags the source", async () => {
     const { client } = await setupLowLevel();
     await client.listTools();
     const result: any = await client.callTool({
       name: "echo",
-      arguments: { text: "hi", context: "testing intent" },
+      arguments: { text: "hi", context: "testing intent", session_id: "start" },
     });
     const block = mintBackOf(result)!;
-    expect(block).toContain("[MCP INSTRUCTIONS]: session_id issued.");
+    expect(block).toContain("[session_id issued");
     expect(block).not.toContain("agent_id");
     const sessionId = handleFrom(block, "session_id");
     expect(sessionId).toMatch(/^ses_/);
@@ -153,16 +154,14 @@ describe("v2 low-level server: explicit handles", () => {
       arguments: { text: "explode", context: "testing" },
     });
     expect(result.isError).toBe(true);
-    expect(mintBackOf(result)).toContain(
-      "[MCP INSTRUCTIONS]: session_id issued.",
-    );
+    expect(mintBackOf(result)).toContain("[session_id issued");
     expect(mintBackOf(result)).not.toContain("agent_id");
 
     const event = capture.findEventByType("mcp:tools/call")!;
     expect(event.isError).toBe(true);
-    expect(JSON.stringify(event.response)).not.toContain("[MCP INSTRUCTIONS]");
+    expect(JSON.stringify(event.response)).not.toContain("[session_id");
     expect(event.error?.message).toContain("boom");
-    expect(event.error?.message).not.toContain("[MCP INSTRUCTIONS]");
+    expect(event.error?.message).not.toContain("[session_id");
     await client.close();
   });
 
@@ -195,13 +194,11 @@ describe("v2 low-level server: explicit handles", () => {
       name: "echo",
       arguments: { text: "hi", context: "testing intent" },
     });
-    expect(mintBackOf(result)).toContain(
-      "[MCP INSTRUCTIONS]: session_id issued.",
-    );
+    expect(mintBackOf(result)).toContain("[session_id issued");
     expect(mintBackOf(result)).not.toContain("agent_id");
 
     const event = capture.findEventByType("mcp:tools/call")!;
-    expect(JSON.stringify(event.response)).not.toContain("[MCP INSTRUCTIONS]");
+    expect(JSON.stringify(event.response)).not.toContain("[session_id");
     expect((event.response as any).content).toEqual([
       { type: "text", text: "echo: hi" },
     ]);
@@ -239,7 +236,7 @@ describe("v2 low-level server: explicit handles", () => {
       },
     });
 
-    expect(mintBackOf(result)).toContain("session_id not recognized");
+    expect(mintBackOf(result)).toContain("[session_id unrecognized");
 
     const event = capture.findEventByType("mcp:tools/call")!;
     expect(event.sessionId).toBe("");

--- a/src/tests/v2/options.test.ts
+++ b/src/tests/v2/options.test.ts
@@ -194,7 +194,7 @@ describe("v2 options: track() edge paths", () => {
       arguments: { msg: "hi", context: "double-track" },
     });
     const blocks = (result.content as any[]).filter(
-      (c) => c.type === "text" && c.text.startsWith("[MCP INSTRUCTIONS]"),
+      (c) => c.type === "text" && c.text.startsWith("[session_id"),
     );
     expect(blocks).toHaveLength(1); // mint-back never doubles
     expect(capture.getEvents()).toHaveLength(1);

--- a/src/tests/v2/pipeline.test.ts
+++ b/src/tests/v2/pipeline.test.ts
@@ -140,7 +140,7 @@ describe("v2 pipeline: publishCustomEvent", () => {
     const mcp = await trackedServer();
 
     await agentcat.publishCustomEvent(mcp, "proj_test", {
-      sessionId: "ses_custom",
+      sessionId: "ses_custom000000000000000000000",
       resourceName: "custom-action",
       parameters: { action: "test" },
       message: "Testing custom event",
@@ -149,7 +149,7 @@ describe("v2 pipeline: publishCustomEvent", () => {
     const events = capture.getEvents();
     expect(events).toHaveLength(1);
     expect(events[0].eventType).toBe(AGENTCAT_CUSTOM_EVENT_TYPE);
-    expect(events[0].sessionId).toBe("ses_custom");
+    expect(events[0].sessionId).toBe("ses_custom000000000000000000000");
     expect(events[0].projectId).toBe("proj_test");
     expect(events[0].resourceName).toBe("custom-action");
     expect(events[0].parameters).toEqual({ action: "test" });
@@ -160,7 +160,7 @@ describe("v2 pipeline: publishCustomEvent", () => {
     const mcp = await trackedServer();
 
     await agentcat.publishCustomEvent(mcp, "proj_test", {
-      sessionId: "ses_custom",
+      sessionId: "ses_custom000000000000000000000",
       resourceName: "custom-action",
       tags: { valid: "value", "bad!key": "value" },
       properties: {},
@@ -211,11 +211,11 @@ describe("v2 pipeline: publishCustomEvent", () => {
 
   it("lets eventData.sessionId take precedence over the session ID string", async () => {
     await agentcat.publishCustomEvent("ignored-string", "proj_test", {
-      sessionId: "ses_wins",
+      sessionId: "ses_wins00000000000000000000000",
     });
 
     const [event] = capture.getEvents();
-    expect(event.sessionId).toBe("ses_wins");
+    expect(event.sessionId).toBe("ses_wins00000000000000000000000");
   });
 
   it("throws for an untracked v2 server", async () => {

--- a/src/tests/v2/schema-edges.test.ts
+++ b/src/tests/v2/schema-edges.test.ts
@@ -3,6 +3,7 @@ import { Server } from "@modelcontextprotocol/server";
 import * as agentcat from "../../index.js";
 import { connectClient } from "./harness.js";
 import { AgentCatOptions } from "../../types.js";
+import { SESSION_ID_PARAM_PATTERN } from "../../modules/constants.js";
 
 /**
  * Injection edge shapes through a real v2 low-level Server: the listing a
@@ -61,8 +62,10 @@ describe("v2 schema edges: input injection", () => {
     const schema = tool.inputSchema as any;
     expect(schema.type).toBe("object");
     expect(schema.properties.session_id).toBeDefined();
+    expect(schema.properties.session_id.pattern).toBe(SESSION_ID_PARAM_PATTERN);
     expect(schema.properties.agent_id).toBeDefined();
     expect(schema.properties.context).toBeDefined();
+    expect(schema.required).toContain("session_id");
     expect(schema.required).toContain("agent_id");
   });
 
@@ -87,8 +90,10 @@ describe("v2 schema edges: input injection", () => {
     const schema = tool.inputSchema as any;
     const props = schema.properties;
     expect(props.session_id.description).toBe("customer session id");
+    expect(props.session_id.pattern).toBeUndefined();
     expect(props.agent_id.description).toBe("customer agent id");
     // Skipped injection must not touch the customer's required semantics.
+    expect(schema.required ?? []).not.toContain("session_id");
     expect(schema.required ?? []).not.toContain("agent_id");
   });
 
@@ -112,7 +117,7 @@ describe("v2 schema edges: input injection", () => {
 });
 
 describe("v2 schema edges: outputSchema injection", () => {
-  it("declares _mcp_instructions in a listed plain-object outputSchema", async () => {
+  it("declares mcp_session in a listed plain-object outputSchema", async () => {
     const listed = await listWithTools([
       {
         name: "stats",
@@ -127,17 +132,16 @@ describe("v2 schema edges: outputSchema injection", () => {
       },
     ]);
     const stats = listed.find((t) => t.name === "stats")!;
-    const prop = ((stats.outputSchema as any).properties as any)
-      ._mcp_instructions;
+    const prop = ((stats.outputSchema as any).properties as any).mcp_session;
     expect(prop.type).toBe("object");
     expect(Object.keys(prop.properties)).toEqual([
       "session_id",
       "agent_id",
-      "instructions",
+      "status",
     ]);
   });
 
-  it("omits agent_id from _mcp_instructions when agent tracking is off", async () => {
+  it("omits agent_id from mcp_session when agent tracking is off", async () => {
     const listed = await listWithTools(
       [
         {
@@ -153,12 +157,8 @@ describe("v2 schema edges: outputSchema injection", () => {
       { enableAgentTracking: false },
     );
     const stats = listed.find((t) => t.name === "stats")!;
-    const prop = ((stats.outputSchema as any).properties as any)
-      ._mcp_instructions;
-    expect(Object.keys(prop.properties)).toEqual([
-      "session_id",
-      "instructions",
-    ]);
+    const prop = ((stats.outputSchema as any).properties as any).mcp_session;
+    expect(Object.keys(prop.properties)).toEqual(["session_id", "status"]);
   });
 
   it("leaves composed (anyOf) outputSchemas untouched", async () => {
@@ -180,13 +180,13 @@ describe("v2 schema edges: outputSchema injection", () => {
     // The engine skips injection (no single properties bag); the v2 wire
     // codec then normalizes the composed schema by nesting it under a
     // `result` property. What matters: the composed shape survives and no
-    // _mcp_instructions declaration was forced into it.
+    // mcp_session declaration was forced into it.
     const serialized = JSON.stringify(tool.outputSchema);
     expect(serialized).toContain('"anyOf"');
-    expect(serialized).not.toContain("_mcp_instructions");
+    expect(serialized).not.toContain("mcp_session");
   });
 
-  it("never overwrites a customer-declared _mcp_instructions output field", async () => {
+  it("never overwrites a customer-declared mcp_session output field", async () => {
     const listed = await listWithTools([
       {
         name: "claims_key",
@@ -195,7 +195,7 @@ describe("v2 schema edges: outputSchema injection", () => {
         outputSchema: {
           type: "object",
           properties: {
-            _mcp_instructions: {
+            mcp_session: {
               type: "string",
               description: "customer-owned field",
             },
@@ -204,8 +204,7 @@ describe("v2 schema edges: outputSchema injection", () => {
       },
     ]);
     const tool = listed.find((t) => t.name === "claims_key")!;
-    const prop = ((tool.outputSchema as any).properties as any)
-      ._mcp_instructions;
+    const prop = ((tool.outputSchema as any).properties as any).mcp_session;
     expect(prop.type).toBe("string");
     expect(prop.description).toBe("customer-owned field");
   });

--- a/src/tests/v2/session-modes.test.ts
+++ b/src/tests/v2/session-modes.test.ts
@@ -51,6 +51,10 @@ describe("v2 session modes: resolveSessionId hook", () => {
     );
     expect((echo.inputSchema as any).properties).toHaveProperty("agent_id");
     expect((echo.inputSchema as any).required).toContain("agent_id");
+    // No session_id injection in hook mode → no session_id requiredness.
+    expect((echo.inputSchema as any).required ?? []).not.toContain(
+      "session_id",
+    );
     // get_more_tools follows the same policy — it publishes events too.
     const gmt = tools.find((t) => t.name === "get_more_tools")!;
     expect((gmt.inputSchema as any).properties).not.toHaveProperty(
@@ -208,6 +212,8 @@ describe("v2 session modes: supplied vs minted (no hook)", () => {
   });
 
   it("mints on omission, announces the id, and tags the source as minted", async () => {
+    // Omission tolerance: a stale schema or scripted caller that never
+    // learned the (now required) parameter must keep working unchanged.
     const { client } = await setupHighLevel();
     const result: any = await client.callTool({
       name: "echo",
@@ -221,6 +227,35 @@ describe("v2 session modes: supplied vs minted (no hook)", () => {
     expect(event.tags).toMatchObject({
       [AGENTCAT_TAG_SESSION_SOURCE]: "minted",
     });
+    await client.close();
+  });
+
+  it("start begins a new task exactly like omission, case-insensitively", async () => {
+    const { client } = await setupHighLevel();
+    const first: any = await client.callTool({
+      name: "echo",
+      arguments: { msg: "one", context: "start task", session_id: "start" },
+    });
+    const firstId = handleFrom(mintBackOf(first)!, "session_id");
+    expect(firstId).toMatch(/^ses_/);
+
+    const second: any = await client.callTool({
+      name: "echo",
+      arguments: { msg: "two", context: "start task", session_id: " START " },
+    });
+    const secondId = handleFrom(mintBackOf(second)!, "session_id");
+    expect(secondId).toMatch(/^ses_/);
+    // start always begins a new, unrelated task — never a shared session.
+    expect(secondId).not.toBe(firstId);
+
+    const events = capture.getEvents();
+    expect(events[0].sessionId).toBe(firstId);
+    expect(events[1].sessionId).toBe(secondId);
+    for (const event of events) {
+      expect(event.tags).toMatchObject({
+        [AGENTCAT_TAG_SESSION_SOURCE]: "minted",
+      });
+    }
     await client.close();
   });
 });

--- a/src/tests/v2/track-highlevel.test.ts
+++ b/src/tests/v2/track-highlevel.test.ts
@@ -46,13 +46,11 @@ describe("track() on v2 McpServer", () => {
     const echo = tools.find((t) => t.name === "echo")!;
     expect((echo.inputSchema as any).properties.session_id).toBeDefined();
     expect((echo.inputSchema as any).properties.context).toBeDefined();
-    expect(
-      (echo.outputSchema as any).properties._mcp_instructions,
-    ).toBeDefined();
+    expect((echo.outputSchema as any).properties.mcp_session).toBeDefined();
     await client.close();
   });
 
-  it("captures events, strips injected args (loose schema), appends mint-back, mirrors structuredContent", async () => {
+  it("captures events, strips injected args (loose schema), prepends mint-back, mirrors structuredContent", async () => {
     const mcp = new McpServer(
       { name: "v2-high", version: "1.0.0" },
       { capabilities: { tools: {} } },
@@ -87,14 +85,12 @@ describe("track() on v2 McpServer", () => {
     expect(lastSeenArgs!.context).toBeUndefined();
     expect(lastSeenArgs!.msg).toBe("hi");
 
-    // Mint-back: trailing text block announces the minted session_id, and the
-    // structured mirror rides structuredContent (validates against the
+    // Mint-back: the FIRST text block announces the minted session_id, and
+    // the structured mirror rides structuredContent (validates against the
     // injected outputSchema — the client checked it).
-    const lastBlock = result.content[result.content.length - 1];
-    expect(lastBlock.text).toContain("[MCP INSTRUCTIONS]");
-    expect(result.structuredContent._mcp_instructions.session_id).toMatch(
-      /^ses_/,
-    );
+    const firstBlock = result.content[0];
+    expect(firstBlock.text).toContain("[session_id issued");
+    expect(result.structuredContent.mcp_session.session_id).toMatch(/^ses_/);
 
     // Event: minted session, userIntent from context, raw args preserved.
     const events = capture.getEvents();

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface AgentCatOptions {
   /**
    * Default false. Set true to inject a required agent_id parameter into every
    * tool. Agents self-generate the value (model|harness|nonce, e.g.
-   * "opus-4.80-1m|claude-code|k3n9x"); it is echoed back in _mcp_instructions
+   * "opus-4.80-1m|claude-code|k3n9x"); it is echoed back in mcp_session
    * and stamped on events as tags. Omission never rejects a call server-side —
    * the event is simply published without agent identity. The intended
    * enforcement is client-side: a strict schema-validating MCP client will
@@ -15,7 +15,7 @@ export interface AgentCatOptions {
   enableAgentTracking?: boolean;
   /**
    * Hook mode: you manage task state. When configured, AgentCat injects no
-   * session_id parameter and prompts no task instructions; the returned value is
+   * session_id parameter and prepends no issuance text; the returned value is
    * combined with the project ID into a deterministic ses_ KSUID. Nullish
    * returns and throws mint silently — a configured hook should answer every
    * request.


### PR DESCRIPTION
Session handles are easy for callers to miss when they arrive at the tail of a long result — clients that truncate large tool outputs can drop the issuance notice entirely, and agents then start new sessions instead of continuing the one they were given. This change makes the handle mechanism sturdier and easier for agents to consume:

- **IDs are issued at the start of the response.** The issuance text block is now the first content element instead of the last, so it survives client-side truncation of long results.
- **`session_id` and `agent_id` are now required parameters with an explicit value contract.** `session_id` takes one of two values — the `ses_` ID issued for the task, or the literal `start` to begin a new one — declared with a validation pattern in the schema (`^(start|ses_[0-9A-Za-z]{27})$`). Every call states its session explicitly, so sessions never split by accident. Servers keep accepting calls that omit the parameters (treated as the start of a new task), so requiredness is enforced only by schema-aware clients and nothing existing breaks server-side.
- **`mcp_session` replaces `_mcp_instructions`** as the structured mirror in `structuredContent`, declared in each tool's output schema. It carries a machine-readable `status` enum (`issued` / `active` / `unrecognized`) instead of prose — every response state an agent can encounter is pre-announced in the schema.
- **Leaner, self-describing parameter copy.** The `session_id` and `agent_id` descriptions now explain the mechanism in terms of what this server does, pre-announce both text-block headers so responses match the schema's stated contract, and collapse the two `agent_id` description variants into one.
- **Recovery is explicit.** An unrecognized value is reported both as `mcp_session.status: "unrecognized"` and as a leading text block, with the recovery path (re-send the earlier ID, or send `start` if none was issued) stated in the schema.

**Breaking wire changes** (for consumers that assert on response internals or schemas): the `structuredContent` mirror key is renamed `_mcp_instructions` → `mcp_session`; its `instructions` string member is removed in favor of `status`; the issuance text block moved from the last to the first content position and its header text changed (`[session_id issued …]` / `[session_id unrecognized …]`); `session_id` and `agent_id` now appear in each tool's `required` array, and `session_id` declares the validation pattern above.

Version bumped to 2.1.0.

**Testing**
- `pnpm build`, `pnpm typecheck`, `pnpm lint` clean
- `pnpm test`: v1 759 passed / 1 skipped, v2 105 passed
- `pnpm test:e2e:http`: 109 passed

Cross-SDK note: this lands the same strings and wire shape in all three SDKs, byte-identical where applicable. Sibling PRs: https://github.com/agentcathq/agentcat-python-sdk/pull/53 · https://github.com/agentcathq/agentcat-go-sdk/pull/13
