### PR TITLE
fix(deps): bump fast-uri to 3.1.7 (GHSA-fph4-wmhf-6fwf, GHSA-5jgf-p345-68v8)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1386,8 +1386,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3074,7 +3074,7 @@ snapshots:
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3445,7 +3445,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:


### PR DESCRIPTION
## What

Bumps the transitive `fast-uri` dependency from **3.1.5** to **3.1.7** in `pnpm-lock.yaml`. No other package moves and `package.json` is untouched.

## Why

Two high-severity (CVSS 7.5) advisories affect `fast-uri` 3.1.x URL parsing (SSRF / host-confusion bugs):

| Advisory | CVE | Vulnerable | Fixed |
|---|---|---|---|
| [GHSA-fph4-wmhf-6fwf](https://github.com/advisories/GHSA-fph4-wmhf-6fwf) | CVE-2026-75899 | `>=3.1.2 <3.1.6` | `3.1.6` |
| [GHSA-5jgf-p345-68v8](https://github.com/advisories/GHSA-5jgf-p345-68v8) | CVE-2026-75931 | `>=3.1.3 <3.1.6` | `3.1.6` |

`3.1.7` is the current `three` dist-tag on npm (published 2026-09-02).

This resolves Dependabot alerts [67](https://github.com/agentcathq/agentcat-typescript-sdk/security/dependabot/67) and [68](https://github.com/agentcathq/agentcat-typescript-sdk/security/dependabot/68). Dependabot is configured with `open-pull-requests-limit: 0` in this org, so this manual PR is the fix path.

**Scope: development only.** `fast-uri` reaches this repo solely through `@modelcontextprotocol/sdk` (a devDependency) -> `ajv 8.17.1` / `ajv-formats` -> `fast-uri`. It is not in the dependency graph of the published `agentcat` npm package, so consumers are not affected.

```
$ pnpm why fast-uri
devDependencies:
@modelcontextprotocol/sdk 1.30.0
├─┬ ajv 8.17.1
│ └── fast-uri 3.1.7
└─┬ ajv-formats 3.0.1
  └─┬ ajv 8.17.1 peer
    └── fast-uri 3.1.7
```

## How

`ajv`'s range is `^3.0.1`, so `3.1.7` is an in-range update and no override is needed. `pnpm update fast-uri --depth Infinity` (pnpm 10.11.0) did land `3.1.7`, but it also re-resolved ~120 unrelated lockfile entries (a duplicate `esbuild@0.28.2` set, a duplicate `rollup@4.63.1` set, `postcss` 8.5.26 -> 8.5.28). To keep the change reviewable, the lockfile edit was reduced to the four `fast-uri` lines (package key, integrity hash from the registry, the `ajv` snapshot reference, and the `fast-uri` snapshot), then validated with a clean frozen install.

```
 pnpm-lock.yaml | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```

## Validation (local, pnpm 10.11.0 via corepack, Node 22)

- `rm -rf node_modules && pnpm install --frozen-lockfile` -> OK; `node_modules/.pnpm` contains only `fast-uri@3.1.7`
- `pnpm run typecheck` -> OK
- `pnpm run lint` -> OK
- `pnpm run test` -> v1: 54 files, 759 passed, 1 skipped; v2: 17 files, 105 passed
- `pnpm run build` -> OK (CJS, ESM, workerd, DTS)
- `pnpm audit --audit-level=high` -> no `fast-uri` findings remain

Not run locally: the Codecov upload (needs `CODECOV_TOKEN`) and the MCP SDK version-compatibility matrix (runs in CI on this PR).

## Out of scope (pre-existing, unchanged by this PR)

`pnpm audit` still reports three unrelated high findings: `path-to-regexp` <8.4.0 ([GHSA-j3q9-mxjg-w52f](https://github.com/advisories/GHSA-j3q9-mxjg-w52f), via `@modelcontextprotocol/sdk > express > router`) and two `brace-expansion` advisories ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)) against the existing exact `brace-expansion: 2.1.2` override. Those existing `pnpm.overrides` were deliberately left as-is here.
